### PR TITLE
Decouple batch querying from graphql-ruby integration.

### DIFF
--- a/graphql-batch.gemspec
+++ b/graphql-batch.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "graphql", "~>0.8"
 
+  spec.add_development_dependency "byebug" if RUBY_ENGINE == 'ruby'
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest"

--- a/lib/graphql/batch.rb
+++ b/lib/graphql/batch.rb
@@ -1,6 +1,48 @@
 require "graphql"
+
+module GraphQL
+  module Batch
+    module_function
+
+    def execute(container)
+      unless container.is_a?(QueryContainer)
+        return container
+      end
+      if container.completed?
+        raise container.error if container.error
+        return container.result
+      end
+
+      batched_queries = Hash.new{ |hash, key| hash[key] = [] }
+      register_queries = lambda do |query_container|
+        query_container.each_query do |query|
+          batched_queries[query.group_key] << query
+        end
+      end
+      register_queries.call(container)
+
+      until batched_queries.empty?
+        queries = batched_queries.shift.last
+        begin
+          queries.first.class.execute(queries)
+        rescue => err
+          queries.each do |query|
+            query.complete(error: err) unless query.completed?
+          end
+        end
+        queries.each do |query|
+          register_queries.call(query)
+        end
+      end
+      raise container.error if container.error
+      container.result
+    end
+  end
+end
+
 require_relative "batch/version"
 require_relative "batch/query_container"
+require_relative "batch/query_callback"
 require_relative "batch/query"
 require_relative "batch/query_group"
 require_relative "batch/execution_strategy"

--- a/lib/graphql/batch/query.rb
+++ b/lib/graphql/batch/query.rb
@@ -1,24 +1,18 @@
 module GraphQL::Batch
   class Query < QueryContainer
-    def initialize(&block)
-      @block = block
+    def initialize
+      raise ArgumentError, "QueryGroup.new no longer takes a block, use #then instead" if block_given?
+      super(self)
+    end
+
+    def each_query
+      return super if @query != self
+      yield self
     end
 
     # batched queries with the same key are merged together
     def group_key
       self.class.name
-    end
-
-    def each_query
-      yield self
-    end
-
-    def complete(result)
-      if @block
-        result = @block.call(result)
-        @block = nil
-      end
-      super(result)
     end
 
     # execute queries, with the same group_key, as a batch

--- a/lib/graphql/batch/query_callback.rb
+++ b/lib/graphql/batch/query_callback.rb
@@ -1,0 +1,16 @@
+module GraphQL::Batch
+  class QueryCallback < QueryContainer
+    def initialize(query, &block)
+      super(query)
+      @block = block
+    end
+
+    def call(result, error)
+      begin
+        complete(@block.call(result, error))
+      rescue => block_error
+        complete(error: block_error)
+      end
+    end
+  end
+end

--- a/lib/graphql/batch/query_container.rb
+++ b/lib/graphql/batch/query_container.rb
@@ -1,30 +1,88 @@
 module GraphQL::Batch
   class QueryContainer
-    attr_accessor :query_listener, :result
+    attr_accessor :query
+    attr_accessor :result, :error
+    attr_accessor :callback
 
-    def each_query
-      raise NotImplementedError
+    def initialize(query)
+      @query = query
     end
 
-    def complete(result)
-      if result.is_a?(QueryContainer)
-        result.query_listener = self
-        register_queries(result)
-      else
-        if instance_variable_defined?(:@result)
-          raise "Query was already completed"
-        end
-        @result = result
-        query_listener.query_completed(self)
+    def each_query
+      @query.each_query { |query| yield query } if @query
+    end
+
+    def then(&block)
+      raise ArgumentError, "Required block not given" unless block
+      on_complete do |result, error|
+        raise error if error
+        block.call(result)
       end
     end
 
-    def query_completed(query)
-      complete(query.result)
+    def rescue(error_class=StandardError, &block)
+      raise ArgumentError, "Required block not given" unless block
+      on_complete do |result, error|
+        if error
+          raise error unless error.is_a?(error_class)
+          block.call(error)
+        else
+          result
+        end
+      end
     end
 
-    def register_queries(query_container)
-      query_listener.register_queries(query_container)
+    def ensure(&block)
+      raise ArgumentError, "Required block not given" unless block
+      on_complete do |result, error|
+        block.call(result, error)
+        raise error if error
+        result
+      end
+    end
+
+    def complete(result = nil, error: nil)
+      if result.is_a?(QueryContainer)
+        @query = result
+        @query.on_complete do |nested_result, nested_error|
+          complete(nested_result, error: nested_error)
+        end
+        return
+      end
+
+      if completed?
+        raise "Query was already completed"
+      end
+      @query = nil
+      @completed = true
+      @result = result
+      @error = error
+      call_callback if @callback
+    end
+
+    def completed?
+      @completed
+    end
+
+    def execute
+      GraphQL::Batch.execute(self)
+    end
+
+    protected
+
+    def on_complete(&block)
+      callback = QueryCallback.new(self, &block)
+      @callback = callback
+      call_callback if completed?
+      callback
+    end
+
+    private
+
+    def call_callback
+      @callback.call(@result, @error)
+      @query = @callback.query
+      @callback = nil
     end
   end
 end

--- a/lib/graphql/batch/query_group.rb
+++ b/lib/graphql/batch/query_group.rb
@@ -1,33 +1,46 @@
 module GraphQL::Batch
   class QueryGroup < QueryContainer
-    def initialize(queries, &block)
-      @pending_queries = queries.dup
-      @pending_queries.each do |query|
-        query.query_listener = self
-      end
-      @block = block
-      raise ArgumentError, "QueryGroup requires a block" unless block
-    end
+    def initialize(queries)
+      raise ArgumentError, "QueryGroup.new no longer takes a block, use #then instead" if block_given?
+      super(self)
+      @pending_queries = Set.new
+      @results = []
 
-    def each_query
-      @pending_queries.each do |query_container|
-        query_container.each_query do |query|
-          yield query
+      queries.each_with_index do |query, i|
+        if query.is_a?(QueryContainer)
+          @pending_queries.add(query)
+        else
+          @results[i] = query
+        end
+      end
+
+      if @pending_queries.empty?
+        complete(@results)
+      else
+        queries.each_with_index do |query, i|
+          next unless query.is_a?(QueryContainer)
+          query.then do |result|
+            @results[i] = result
+            @pending_queries.delete(query)
+            if @pending_queries.empty?
+              complete(@results)
+            end
+          end.rescue do |err|
+            unless completed?
+              @pending_queries = nil
+              @results = nil
+              complete(error: err)
+            end
+          end
         end
       end
     end
 
-    def query_completed(query)
-      @pending_queries.delete(query)
-      if @pending_queries.empty?
-        result = @block.call
-        @block = nil
-        if result.is_a?(QueryContainer)
-          result.query_listener = self
-          @pending_queries << result
-          register_queries(result)
-        else
-          complete(result)
+    def each_query
+      return super if completed?
+      @pending_queries.each do |query_container|
+        query_container.each_query do |query|
+          yield query
         end
       end
     end

--- a/lib/graphql/batch/version.rb
+++ b/lib/graphql/batch/version.rb
@@ -1,5 +1,5 @@
 module Graphql
   module Batch
-    VERSION = "0.1.0"
+    VERSION = "0.2.0"
   end
 end

--- a/test/query_test.rb
+++ b/test/query_test.rb
@@ -1,0 +1,115 @@
+require_relative 'test_helper'
+
+class GraphQL::Batch::QueryTest < Minitest::Test
+  class GroupCountQuery < GraphQL::Batch::Query
+    def initialize(key, &block)
+      @key = key
+      super(&block)
+    end
+
+    def group_key
+      @key
+    end
+
+    def self.execute(queries)
+      queries.each do |query|
+        query.complete(queries.size)
+      end
+    end
+  end
+
+  class EchoQuery < GraphQL::Batch::Query
+    attr_reader :value
+
+    def initialize(value, &block)
+      @value = value
+      super(&block)
+    end
+
+    def group_key
+      object_id
+    end
+
+    def self.execute(queries)
+      queries.each do |query|
+        query.complete(query.value)
+      end
+    end
+  end
+
+
+  def test_single_query
+    assert_equal 1, GroupCountQuery.new("single").execute
+  end
+
+  def test_query_group
+    group = GraphQL::Batch::QueryGroup.new([
+      GroupCountQuery.new("two"),
+      GroupCountQuery.new("one"),
+      GroupCountQuery.new("two"),
+    ])
+    assert_equal [2, 1, 2], group.execute
+  end
+
+  def test_empty_group_query
+    assert_equal [], GraphQL::Batch::QueryGroup.new([]).execute
+  end
+
+  def test_group_query_with_non_queries
+    assert_equal [1, :a, 'b'], GraphQL::Batch::QueryGroup.new([1, :a, 'b']).execute
+  end
+
+  def test_group_query_with_some_queries
+    group = GraphQL::Batch::QueryGroup.new([
+      GroupCountQuery.new("two"),
+      'one',
+      GroupCountQuery.new("two"),
+    ])
+    assert_equal [2, 'one', 2], group.execute
+  end
+
+  def test_then
+    assert_equal 3, GroupCountQuery.new("single").then { |value| value + 2 }.execute
+  end
+
+  def test_then_error
+    query = GroupCountQuery.new("single").then { raise "oops" }
+    assert_raises(RuntimeError, 'oops') do
+      query.execute
+    end
+  end
+
+  def test_rescue_without_error
+    assert_equal 3, GroupCountQuery.new("single").then { |value| value + 2 }.rescue { |err| err.message }.execute
+  end
+
+  def test_rescue_with_error
+    query = GroupCountQuery.new("single").then { raise "oops" }.rescue { |err| err.message }
+    assert_equal 'oops', query.execute
+  end
+
+  def test_ensure
+    ensure_args = nil
+    query = GroupCountQuery.new("single").ensure do |value, error|
+      ensure_args = [value, error]
+      value + 2
+    end
+    assert_equal 1, query.execute
+    assert_equal [1, nil], ensure_args
+  end
+
+  def test_ensure_with_error
+    ensure_args = nil
+    query = GroupCountQuery.new("single").then { raise "oops" }.ensure do |value, error|
+      ensure_args = [value, error]
+      error.message
+    end
+    assert_raises(RuntimeError, "oops") { query.execute }
+    assert_nil ensure_args[0]
+    assert_equal "oops", ensure_args[1].message
+  end
+
+  def test_query_in_callback
+    assert_equal 5, EchoQuery.new(4).then { |value| EchoQuery.new(value + 1) }.execute
+  end
+end


### PR DESCRIPTION
@eapache for review

## Problem

I want to test that all the computed fields on objects are being preloaded properly.  This means that all loading happens during the preload, since loading an association on an individual object will result in an N+1.

This will require exposing the ability to call the preload code without it calling the wrapped resolver, as well as the ability to execute any batch queries that are returned the preload code.  The latter is a problem in graphql-batch because the code to execute those queries was coupled with the code to integrate with graphql-ruby.

## Solution

I added a `GraphQL::Batch.execute` method that can execute a query container (single query or query group) along with any query container that is returned from a callback of that query.  I have also added a `GraphQL::Batch::QueryContainer#execute` method to make it even easier to execute queries.

Another aspect of this refactoring to remove coupling of GraphQL::Batch::ExecutionStrategy with the other code was to allow callbacks to be added on a `GraphQL::Batch::QueryContainer` after it was returned from the resolve proc.  Previously this chaining was done by passing a block to `GraphQL::Batch::Query.new` or `GraphQL::Batch::QueryGroup.new`.  Now `#then` can be used to lazily add a callback.

I also needed to handle query exceptions in GraphQL::Batch::ExecutionStrategy, so added `#rescue` and `#ensure` on GraphQL::Batch::QueryContainer to handle this in a way that seems somewhat natural for ruby.