### PR TITLE
fix: Wait for subpromises after a list promise is resolved.

### DIFF
--- a/lib/graphql/batch/execution_strategy.rb
+++ b/lib/graphql/batch/execution_strategy.rb
@@ -1,12 +1,16 @@
 module GraphQL::Batch
   class ExecutionStrategy < GraphQL::Query::SerialExecution
     def execute(_, _, _)
-      as_promise_unless_resolved(super).sync
+      as_promise(super).sync
     ensure
       GraphQL::Batch::Executor.current.clear
     end
 
     private
+
+    def as_promise(result)
+      GraphQL::Batch::Promise.resolve(as_promise_unless_resolved(result))
+    end
 
     def as_promise_unless_resolved(result)
       all_promises = []

--- a/lib/graphql/batch/execution_strategy.rb
+++ b/lib/graphql/batch/execution_strategy.rb
@@ -19,7 +19,10 @@ module GraphQL::Batch
         all_promises = []
         each_promise(result) do |obj, key, promise|
           obj[key] = nil
-          all_promises << promise.then { |value| obj[key] = value }
+          all_promises << promise.then { |value|
+            obj[key] = value
+            as_promise_unless_resolved(value)
+          }
         end
         return result if all_promises.empty?
         Promise.all(all_promises).then { result }

--- a/lib/graphql/batch/execution_strategy.rb
+++ b/lib/graphql/batch/execution_strategy.rb
@@ -1,52 +1,43 @@
 module GraphQL::Batch
   class ExecutionStrategy < GraphQL::Query::SerialExecution
-    class OperationResolution < GraphQL::Query::SerialExecution::OperationResolution
-      def result
-        GraphQL::Batch::Promise.resolve(super).sync
-      ensure
-        GraphQL::Batch::Executor.current.clear
+    def execute(_, _, _)
+      as_promise(super).sync
+    ensure
+      GraphQL::Batch::Executor.current.clear
+    end
+
+    private
+
+    def as_promise(result)
+      all_promises = []
+      each_promise(result) do |obj, key, promise|
+        obj[key] = nil
+        all_promises << promise.then do |value|
+          obj[key] = value
+          as_promise(result)
+        end
+      end
+      Promise.all(all_promises).then { result }
+    end
+
+    def each_promise(obj, &block)
+      case obj
+      when Array
+        obj.each_with_index do |value, idx|
+          each_promise_in_entry(obj, idx, value, &block)
+        end
+      when Hash
+        obj.each do |key, value|
+          each_promise_in_entry(obj, key, value, &block)
+        end
       end
     end
 
-    class SelectionResolution < GraphQL::Query::SerialExecution::SelectionResolution
-      def result
-        as_promise_unless_resolved(super)
-      end
-
-      private
-
-      def as_promise_unless_resolved(result)
-        all_promises = []
-        each_promise(result) do |obj, key, promise|
-          obj[key] = nil
-          all_promises << promise.then { |value|
-            obj[key] = value
-            as_promise_unless_resolved(value)
-          }
-        end
-        return result if all_promises.empty?
-        Promise.all(all_promises).then { result }
-      end
-
-      def each_promise(obj, &block)
-        case obj
-        when Array
-          obj.each_with_index do |value, idx|
-            each_promise_in_entry(obj, idx, value, &block)
-          end
-        when Hash
-          obj.each do |key, value|
-            each_promise_in_entry(obj, key, value, &block)
-          end
-        end
-      end
-
-      def each_promise_in_entry(obj, key, value, &block)
-        if value.is_a?(::Promise)
-          yield obj, key, value
-        else
-          each_promise(value, &block)
-        end
+    def each_promise_in_entry(obj, key, value, &block)
+      if value.is_a?(::Promise)
+        yield obj, key, value
+      else
+        each_promise(value, &block)
       end
     end
 

--- a/test/batch_test.rb
+++ b/test/batch_test.rb
@@ -5,6 +5,18 @@ class Graphql::BatchTest < Minitest::Test
     QUERIES.clear
   end
 
+  def test_no_queries
+    query_string = '{ constant }'
+    result = Schema.execute(query_string, debug: true)
+    expected = {
+      "data" => {
+        "constant" => "constant value"
+      }
+    }
+    assert_equal expected, result
+    assert_equal [], QUERIES
+  end
+
   def test_single_query
     query_string = <<-GRAPHQL
       {

--- a/test/batch_test.rb
+++ b/test/batch_test.rb
@@ -169,4 +169,42 @@ class Graphql::BatchTest < Minitest::Test
     assert_equal expected, result
     assert_equal ["Product/1", "Image/1", "Product/1/variants", "ProductVariant/1,2/images"], QUERIES
   end
+
+  def test_load_list_of_objects_with_loaded_field
+    query_string = <<-GRAPHQL
+      {
+        products(first: 2) {
+          id
+          variants {
+            id
+            image_ids
+          }
+        }
+      }
+    GRAPHQL
+    result = Schema.execute(query_string, debug: true)
+    expected = {
+      "data" => {
+        "products" => [
+          {
+            "id" => "1",
+            "variants" => [
+              { "id" => "1", "image_ids" => ["4"] },
+              { "id" => "2", "image_ids" => ["5"] },
+            ],
+          },
+          {
+            "id" => "2",
+            "variants" => [
+              { "id" => "4", "image_ids" => [] },
+              { "id" => "5", "image_ids" => [] },
+              { "id" => "6", "image_ids" => [] },
+            ],
+          }
+        ]
+      }
+    }
+    assert_equal expected, result
+    assert_equal ["Product?limit=2", "Product/1,2/variants", "ProductVariant/1,2,4,5,6/images"], QUERIES
+  end
 end

--- a/test/support/schema.rb
+++ b/test/support/schema.rb
@@ -60,6 +60,10 @@ end
 QueryType = GraphQL::ObjectType.define do
   name "Query"
 
+  field :constant, !types.String do
+    resolve ->(_, _, _) { "constant value" }
+  end
+
   field :product do
     type ProductType
     argument :id, !types.ID

--- a/test/support/schema.rb
+++ b/test/support/schema.rb
@@ -10,6 +10,13 @@ ProductVariantType = GraphQL::ObjectType.define do
 
   field :id, !types.ID
   field :title, !types.String
+  field :image_ids, !types[types.ID] do
+    resolve ->(variant, _, _) {
+      AssociationLoader.for(ProductVariant, :images).load(variant).then do |images|
+        images.map(&:id)
+      end
+    }
+  end
 end
 
 ProductType = GraphQL::ObjectType.define do


### PR DESCRIPTION
@eapache for review

## Problem

There was a bug in https://github.com/Shopify/graphql-batch/pull/3 with waiting for promises in the result of a selection for a list.  E.g. a selection for products would resolve to a list of promises for the variants if any batch loads were needed for variant fields.

## Solution

After assigning the result of a promise for a selection to a field, I recursively called the code to turn a value into a promise to return from the `.then` block so that the outer `Promise.all` would wait for that promise.

Previously the wrapping of values with promises was handled in the selection resolution for each object.  However, since we need to handle sub-promises, we can move the promise wrapping so that it is done once (recursively) for the whole operation.  I think this also simplifies the code and makes this type of bug harder to miss.