### PR TITLE
Improve error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ class RecordLoader < GraphQL::Batch::Loader
   end
 
   def perform(ids)
-    @model.find(ids).each { |record| fulfill(record.id, record) }
+    @model.where(id: ids).each { |record| fulfill(record.id, record) }
+    ids.each { |id| fulfill(id, nil) unless fulfilled?(id) }
   end
 end
 ```

--- a/lib/graphql/batch.rb
+++ b/lib/graphql/batch.rb
@@ -3,6 +3,7 @@ require "promise.rb"
 
 module GraphQL
   module Batch
+    BrokenPromiseError = Class.new(StandardError)
   end
 end
 

--- a/lib/graphql/batch/executor.rb
+++ b/lib/graphql/batch/executor.rb
@@ -22,7 +22,10 @@ module GraphQL::Batch
     end
 
     def wait(promise)
-      tick while promise.pending?
+      tick while promise.pending? && !loaders.empty?
+      if promise.pending?
+        promise.reject(BrokenPromiseError.new("Promise wasn't fulfilled after all queries were loaded"))
+      end
     end
 
     def clear

--- a/lib/graphql/batch/loader.rb
+++ b/lib/graphql/batch/loader.rb
@@ -20,6 +20,10 @@ module GraphQL::Batch
       promises_by_key[key].fulfill(value)
     end
 
+    def fulfilled?(key)
+      promises_by_key[key].fulfilled?
+    end
+
     # batch load keys and fulfill promises
     def perform(keys)
       raise NotImplementedError

--- a/lib/graphql/batch/loader.rb
+++ b/lib/graphql/batch/loader.rb
@@ -27,9 +27,20 @@ module GraphQL::Batch
 
     def resolve
       perform(keys)
+      check_for_broken_promises
     rescue => err
       promises_by_key.each do |key, promise|
         promise.reject(err)
+      end
+    end
+
+    private
+
+    def check_for_broken_promises
+      promises_by_key.each do |key, promise|
+        if promise.pending?
+          promise.reject(BrokenPromiseError.new("#{self.class} didn't fulfill promise for key #{key.inspect}"))
+        end
       end
     end
   end

--- a/test/batch_test.rb
+++ b/test/batch_test.rb
@@ -57,6 +57,21 @@ class Graphql::BatchTest < Minitest::Test
     assert_equal ["Product/1,2"], QUERIES
   end
 
+  def test_record_missing
+    query_string = <<-GRAPHQL
+      {
+        product(id: "123") {
+          id
+          title
+        }
+      }
+    GRAPHQL
+    result = Schema.execute(query_string, debug: true)
+    expected = { "data" => { "product" => nil } }
+    assert_equal expected, result
+    assert_equal ["Product/123"], QUERIES
+  end
+
   def test_batched_association_preload
     query_string = <<-GRAPHQL
       {

--- a/test/batch_test.rb
+++ b/test/batch_test.rb
@@ -234,4 +234,19 @@ class Graphql::BatchTest < Minitest::Test
     assert_equal expected, result
     assert_equal ["Product?limit=2", "Product/1,2/variants", "ProductVariant/1,2,4,5,6/images"], QUERIES
   end
+
+  def test_load_error
+    query_string = <<-GRAPHQL
+      {
+        constant
+        load_execution_error
+      }
+    GRAPHQL
+    result = Schema.execute(query_string, debug: true)
+    expected = {
+      "data" => { "constant"=>"constant value", "load_execution_error" => nil },
+      "errors" => [{ "message" => "test error message", "locations"=>[{"line"=>3, "column"=>9}]}],
+    }
+    assert_equal expected, result
+  end
 end

--- a/test/loader_test.rb
+++ b/test/loader_test.rb
@@ -77,4 +77,11 @@ class GraphQL::Batch::LoaderTest < Minitest::Test
   def test_query_in_callback
     assert_equal 5, EchoLoader.for().load(4).then { |value| EchoLoader.for().load(value + 1) }.sync
   end
+
+  def test_broken_promise_executor_check
+    promise = GraphQL::Batch::Promise.new
+    promise.wait
+    assert_equal promise.reason.class, GraphQL::Batch::BrokenPromiseError
+    assert_equal promise.reason.message, "Promise wasn't fulfilled after all queries were loaded"
+  end
 end

--- a/test/loader_test.rb
+++ b/test/loader_test.rb
@@ -11,10 +11,13 @@ class GraphQL::Batch::LoaderTest < Minitest::Test
   end
 
   class EchoLoader < GraphQL::Batch::Loader
-    attr_reader :value
-
     def perform(keys)
       keys.each { |key| fulfill(key, key) }
+    end
+  end
+
+  class BrokenLoader < GraphQL::Batch::Loader
+    def perform(keys)
     end
   end
 
@@ -83,5 +86,12 @@ class GraphQL::Batch::LoaderTest < Minitest::Test
     promise.wait
     assert_equal promise.reason.class, GraphQL::Batch::BrokenPromiseError
     assert_equal promise.reason.message, "Promise wasn't fulfilled after all queries were loaded"
+  end
+
+  def test_broken_promise_loader_check
+    promise = BrokenLoader.for().load(1)
+    promise.wait
+    assert_equal promise.reason.class, GraphQL::Batch::BrokenPromiseError
+    assert_equal promise.reason.message, "#{BrokenLoader.name} didn't fulfill promise for key 1"
   end
 end

--- a/test/support/db.rb
+++ b/test/support/db.rb
@@ -11,7 +11,7 @@ module ModelClassMethods
   def find(ids)
     ids = Array(ids)
     QUERIES << "#{name}/#{ids.join(',')}"
-    ids.map{ |id| fixtures[id].dup }.compact
+    ids.map{ |id| fixtures[id] }.compact.map(&:dup)
   end
 
   def preload_association(owners, association)

--- a/test/support/loaders.rb
+++ b/test/support/loaders.rb
@@ -9,6 +9,7 @@ class RecordLoader < GraphQL::Batch::Loader
 
   def perform(ids)
     @model.find(ids).each { |record| fulfill(record.id, record) }
+    ids.each { |id| fulfill(id, nil) unless fulfilled?(id) }
   end
 end
 

--- a/test/support/schema.rb
+++ b/test/support/schema.rb
@@ -64,6 +64,14 @@ QueryType = GraphQL::ObjectType.define do
     resolve ->(_, _, _) { "constant value" }
   end
 
+  field :load_execution_error, types.String do
+    resolve ->(_, _, _) {
+      RecordLoader.for(Product).load(1).then do |product|
+        raise GraphQL::ExecutionError, "test error message"
+      end
+    }
+  end
+
   field :product do
     type ProductType
     argument :id, !types.ID


### PR DESCRIPTION
@eapache for review

## Problem

I noticed a problem with the RecordLoader example in the README when records were missing.  We weren't fulfilling the load for ids if they are missing in the query result.

When we do come across a bug in a loader, we should also make these errors easier to debug by checking for unfulfilled promises in the loader and in the executor to provide a helpful error message.

I also noticed that we aren't actually handling a GraphQL::ExecutionError properly, since it wasn't behaving as if the error was raised in a field's resolve proc.  The error was causing the whole request to fail, without showing other fields, instead of being treated as a field error.

## Solution

* I added `GraphQL::Batch::Loader#fulfilled?` to make it easier to check for unfulfilled promises in `#perform`
* GraphQL::Batch::Loader#resolve now raises GraphQL::Batch::BrokenPromiseError if a promise is still pending after `#perform`
* GraphQL::Batch::Executor#wait now raises GraphQL::Batch::BrokenPromiseError if the promise is still pending after all loads have been performed
* I added an on_reject handler in the get_finished_value override in the execution strategy