### PR TITLE
Pass execution error to super in get_finished_value override

### DIFF
--- a/lib/graphql/batch/execution_strategy.rb
+++ b/lib/graphql/batch/execution_strategy.rb
@@ -50,10 +50,7 @@ module GraphQL::Batch
       def get_finished_value(raw_value)
         if raw_value.is_a?(::Promise)
           raw_value.then(->(result) { super(result) }, lambda do |error|
-            raise error unless error.is_a?(GraphQL::ExecutionError)
-            error.ast_node = ast_node
-            query.context.errors << error
-            nil
+            error.is_a?(GraphQL::ExecutionError) ? super(error) : raise(error)
           end)
         else
           super


### PR DESCRIPTION
@eapache for review

This simplification avoids interfering with the changes made in https://github.com/rmosolgo/graphql-ruby/pull/94, working in conjunction with my upstream pull request https://github.com/rmosolgo/graphql-ruby/pull/100 which allows this to keep working on the next version of graphql-ruby.