### PR TITLE
Add support for checking for unbatched queries by checking a loading flag

### DIFF
--- a/lib/graphql/batch/promise.rb
+++ b/lib/graphql/batch/promise.rb
@@ -3,5 +3,9 @@ module GraphQL::Batch
     def wait
       Executor.current.wait(self)
     end
+
+    def defer
+      Executor.current.defer { super }
+    end
   end
 end

--- a/test/batch_test.rb
+++ b/test/batch_test.rb
@@ -1,8 +1,15 @@
 require_relative 'test_helper'
 
 class GraphQL::BatchTest < Minitest::Test
+  attr_reader :queries
+
   def setup
-    QUERIES.clear
+    @queries = []
+    QueryNotifier.subscriber = ->(query) { @queries << query }
+  end
+
+  def teardown
+    QueryNotifier.subscriber = nil
   end
 
   def test_no_queries
@@ -14,7 +21,7 @@ class GraphQL::BatchTest < Minitest::Test
       }
     }
     assert_equal expected, result
-    assert_equal [], QUERIES
+    assert_equal [], queries
   end
 
   def test_single_query
@@ -36,7 +43,7 @@ class GraphQL::BatchTest < Minitest::Test
       }
     }
     assert_equal expected, result
-    assert_equal ["Product/1"], QUERIES
+    assert_equal ["Product/1"], queries
   end
 
   def test_batched_find_by_id
@@ -54,7 +61,7 @@ class GraphQL::BatchTest < Minitest::Test
       }
     }
     assert_equal expected, result
-    assert_equal ["Product/1,2"], QUERIES
+    assert_equal ["Product/1,2"], queries
   end
 
   def test_record_missing
@@ -69,7 +76,7 @@ class GraphQL::BatchTest < Minitest::Test
     result = Schema.execute(query_string, debug: true)
     expected = { "data" => { "product" => nil } }
     assert_equal expected, result
-    assert_equal ["Product/123"], QUERIES
+    assert_equal ["Product/123"], queries
   end
 
   def test_batched_association_preload
@@ -110,7 +117,7 @@ class GraphQL::BatchTest < Minitest::Test
       }
     }
     assert_equal expected, result
-    assert_equal ["Product?limit=2", "Product/1,2/variants"], QUERIES
+    assert_equal ["Product?limit=2", "Product/1,2/variants"], queries
   end
 
   def test_query_group_with_single_query
@@ -154,7 +161,7 @@ class GraphQL::BatchTest < Minitest::Test
       }
     }
     assert_equal expected, result
-    assert_equal ["Product?limit=2", "Product/1,2/variants"], QUERIES
+    assert_equal ["Product?limit=2", "Product/1,2/variants"], queries
   end
 
   def test_sub_queries
@@ -170,7 +177,7 @@ class GraphQL::BatchTest < Minitest::Test
       }
     }
     assert_equal expected, result
-    assert_equal ["Product/2", "Product/2/variants"], QUERIES
+    assert_equal ["Product/2", "Product/2/variants"], queries
   end
 
   def test_query_group_with_sub_queries
@@ -194,7 +201,7 @@ class GraphQL::BatchTest < Minitest::Test
       }
     }
     assert_equal expected, result
-    assert_equal ["Product/1", "Image/1", "Product/1/variants", "ProductVariant/1,2/images"], QUERIES
+    assert_equal ["Product/1", "Image/1", "Product/1/variants", "ProductVariant/1,2/images"], queries
   end
 
   def test_load_list_of_objects_with_loaded_field
@@ -232,7 +239,7 @@ class GraphQL::BatchTest < Minitest::Test
       }
     }
     assert_equal expected, result
-    assert_equal ["Product?limit=2", "Product/1,2/variants", "ProductVariant/1,2,4,5,6/images"], QUERIES
+    assert_equal ["Product?limit=2", "Product/1,2/variants", "ProductVariant/1,2,4,5,6/images"], queries
   end
 
   def test_load_error

--- a/test/executor_test.rb
+++ b/test/executor_test.rb
@@ -1,0 +1,41 @@
+require_relative 'test_helper'
+
+class GraphQL::Batch::ExecutorTest < Minitest::Test
+  def test_loading_flag_when_not_loading
+    assert_equal false, GraphQL::Batch::Executor.current.loading
+  end
+
+  class TestLoader < GraphQL::Batch::Loader
+    attr_reader :number, :loading_in_perform
+
+    def initialize(number)
+      @number
+    end
+
+    def perform(keys)
+      @loading_in_perform = GraphQL::Batch::Executor.current.loading
+      keys.each { |key| fulfill(key, key) }
+    end
+  end
+
+  def test_loading_flag_in_loader_perform
+    loader = TestLoader.for(1)
+    loader.load(:key).sync
+    assert_equal true, loader.loading_in_perform
+  end
+
+  def test_loading_flag_in_callback
+    loading_in_callback = nil
+    TestLoader.for(1).load(:key).then { loading_in_callback = GraphQL::Batch::Executor.current.loading }.sync
+    assert_equal false, loading_in_callback
+  end
+
+  def test_loading_flag_in_nested_load
+    loader2 = nil
+    TestLoader.for(1).load(:key).then do
+      loader2 = TestLoader.for(2)
+      loader2.load(:key2)
+    end.sync
+    assert_equal true, loader2.loading_in_perform
+  end
+end


### PR DESCRIPTION
@eapache for review

## Problem

When depending on GraphQL::Batch for avoiding N+1 queries, it becomes important to test for unbatched queries.

I have managed to accomplish that by overriding GraphQL::Field to separate the resolver into a preload_proc and a resolve_proc, so the preload_proc can do the batch loading then we can assert no queries are performed in the resolve_proc.  However, this required the result of the preload_proc to be memoized so it could be used in the resolve_proc and also doesn't test the normal code path for executing a graphql query.

## Solution

Add a GraphQL::Batch::Executor#loading attribute which is set to `true` when performing a batch load and `false` otherwise.

This could be used in an `ActiveSupport::Notifications.subscribe` block to detect queries that are performed while GraphQL::Batch::Executor#loading is `false`, even in an integration test.