### PR TITLE
Fix errant `Graphql` constant

### DIFF
--- a/graphql-batch.gemspec
+++ b/graphql-batch.gemspec
@@ -5,7 +5,7 @@ require 'graphql/batch/version'
 
 Gem::Specification.new do |spec|
   spec.name          = "graphql-batch"
-  spec.version       = Graphql::Batch::VERSION
+  spec.version       = GraphQL::Batch::VERSION
   spec.authors       = ["Dylan Thacker-Smith"]
   spec.email         = ["Dylan.Smith@shopify.com"]
 

--- a/lib/graphql/batch/version.rb
+++ b/lib/graphql/batch/version.rb
@@ -1,4 +1,4 @@
-module Graphql
+module GraphQL
   module Batch
     VERSION = "0.2.2"
   end

--- a/test/batch_test.rb
+++ b/test/batch_test.rb
@@ -1,6 +1,6 @@
 require_relative 'test_helper'
 
-class Graphql::BatchTest < Minitest::Test
+class GraphQL::BatchTest < Minitest::Test
   def setup
     QUERIES.clear
   end


### PR DESCRIPTION
In `lib/graphql/batch/version`, we're accidentally defining a top-level constant that's unused anywhere else in the ecosystem: `Graphql`. It looks like this probably happened during generating the gem, but was never updated to match the `GraphQL` constant that's used everywhere else in this gem and other gems.