### PR TITLE
Also group loaders by their class

### DIFF
--- a/lib/graphql/batch/loader.rb
+++ b/lib/graphql/batch/loader.rb
@@ -1,7 +1,8 @@
 module GraphQL::Batch
   class Loader
     def self.for(*group_args)
-      Executor.current.loaders[group_args] ||= new(*group_args)
+      loader_key = [self].concat(group_args)
+      Executor.current.loaders[loader_key] ||= new(*group_args)
     end
 
     def promises_by_key


### PR DESCRIPTION
@eapache for review

## Problem

Loaders that take the same grouping arguments to the `for` method can cause conflicts.  This becomes obvious when working with singleton loaders, loaders with no grouping arguments passed to `for`.  In these cases, loads from different loaders will get grouped together and performed using the loader instance for the first class used for batch loading.

## Solution

Prepend the loader class to the grouping arguments to use for the loader key.