### PR TITLE
Nicer syntax for parameterless executors

### DIFF
--- a/lib/graphql/batch/loader.rb
+++ b/lib/graphql/batch/loader.rb
@@ -5,6 +5,14 @@ module GraphQL::Batch
       Executor.current.loaders[loader_key] ||= new(*group_args)
     end
 
+    def self.load(key)
+      self.for.load(key)
+    end
+
+    def self.load_many(keys)
+      self.for.load_many(keys)
+    end
+
     def promises_by_key
       @promises_by_key ||= {}
     end

--- a/test/loader_test.rb
+++ b/test/loader_test.rb
@@ -47,7 +47,7 @@ class GraphQL::Batch::LoaderTest < Minitest::Test
   end
 
   def test_query_many
-    assert_equal [:a, :b, :c], EchoLoader.for().load_many([:a, :b, :c]).sync
+    assert_equal [:a, :b, :c], EchoLoader.load_many([:a, :b, :c]).sync
   end
 
   def test_empty_group_query
@@ -88,7 +88,7 @@ class GraphQL::Batch::LoaderTest < Minitest::Test
   end
 
   def test_query_in_callback
-    assert_equal 5, EchoLoader.for().load(4).then { |value| EchoLoader.for().load(value + 1) }.sync
+    assert_equal 5, EchoLoader.load(4).then { |value| EchoLoader.load(value + 1) }.sync
   end
 
   def test_broken_promise_executor_check
@@ -99,7 +99,7 @@ class GraphQL::Batch::LoaderTest < Minitest::Test
   end
 
   def test_broken_promise_loader_check
-    promise = BrokenLoader.for().load(1)
+    promise = BrokenLoader.load(1)
     promise.wait
     assert_equal promise.reason.class, GraphQL::Batch::BrokenPromiseError
     assert_equal promise.reason.message, "#{BrokenLoader.name} didn't fulfill promise for key 1"
@@ -107,8 +107,8 @@ class GraphQL::Batch::LoaderTest < Minitest::Test
 
   def test_loader_class_grouping
     group = GraphQL::Batch::Promise.all([
-      EchoLoader.for().load(:a),
-      IncrementLoader.for().load(1),
+      EchoLoader.load(:a),
+      IncrementLoader.load(1),
     ])
     assert_equal [:a, 2], group.sync
   end


### PR DESCRIPTION
Not all loaders require parameters, and using this is a bit awkward:

    promise = SpecialLoader.for.load(1)

This is a bit nicer:

    promise = SpecialLoader.load(1)

After this change, tests still passing:

```
Finished in 0.017371s, 1669.4325 runs/s, 2302.6655 assertions/s.
29 runs, 40 assertions, 0 failures, 0 errors, 0 skips
```