### PR TITLE
Add explicitly check for promise key presence in fulfillment methods, error message

### DIFF
--- a/lib/graphql/batch/loader.rb
+++ b/lib/graphql/batch/loader.rb
@@ -30,10 +30,12 @@ module GraphQL::Batch
     end
 
     def fulfill(key, value)
+      expect_promise_key!(key)
       promises_by_key[key].fulfill(value)
     end
 
     def fulfilled?(key)
+      expect_promise_key!(key)
       promises_by_key[key].fulfilled?
     end
 
@@ -52,6 +54,10 @@ module GraphQL::Batch
     end
 
     private
+
+    def expect_promise_key!(key)
+      raise "No promise with key #{key} to fulfill" unless promises_by_key.key?(key)
+    end
 
     def check_for_broken_promises
       promises_by_key.each do |key, promise|


### PR DESCRIPTION
Right now if there's a mismatch in promise keys, through programmer mistake, a call to `#fulfill` and `#fulfilled?` will be made on `nil`. For example:

```ruby
class SomeLoader
  # ...
  def load(ids)
    # ids is an array of strings, which ActiveRecord happily works with

    # when fulfilling the promise, I use the #id on the record, an int
    @model.where(id: ids).each { |record| fulfill(record.id, record) }
  end
end
```

And then in `lib/graphql/batch/loader.rb`
```ruby
def fulfill(key, value)
  # promises_by_key[key] #=> nil
  promises_by_key[key].fulfill(value)
end
```

While this mistake was my fault alone, it seems like it'd be a common enough case (specially in the early stages of a project) where an explicit check and accompanying error is warranted.

I was only going to open an issue, but decided to go ahead and add some code to match, while trying to change as little as possible of what was already in place.