### PR TITLE
Fix tests on latest graphql

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # GraphQL::Batch
 
+[![Build Status](https://travis-ci.org/Shopify/graphql-batch.svg?branch=master)](https://travis-ci.org/Shopify/graphql-batch)
+[![Gem Version](https://badge.fury.io/rb/graphql-batch.svg)](https://rubygems.org/gems/graphql-batch)
+
 Provides an executor for the [`graphql` gem](https://github.com/rmosolgo/graphql-ruby) which allows queries to be batched.
 
 ## Installation

--- a/test/batch_test.rb
+++ b/test/batch_test.rb
@@ -252,7 +252,7 @@ class GraphQL::BatchTest < Minitest::Test
     result = Schema.execute(query_string)
     expected = {
       "data" => { "constant"=>"constant value", "load_execution_error" => nil },
-      "errors" => [{ "message" => "test error message", "locations"=>[{"line"=>3, "column"=>9}]}],
+      "errors" => [{ "message" => "test error message", "locations"=>[{"line"=>3, "column"=>9}], "path" => ["load_execution_error"] }],
     }
     assert_equal expected, result
   end


### PR DESCRIPTION
Noticed our tests were failing on the latest version of `graphql-ruby`. This fixes it.

Also added badges to the README.

There's a ton of warnings when we run the tests which we may want to fix, but that can be done outside this PR.

cc @dylanahsmith 