### PR TITLE
Add regression test for execution errors in non-nullable fields

### DIFF
--- a/test/batch_test.rb
+++ b/test/batch_test.rb
@@ -79,6 +79,33 @@ class GraphQL::BatchTest < Minitest::Test
     assert_equal ["Product/123"], queries
   end
 
+  def test_non_null_field_that_raises_on_nullable_parent
+    query_string = <<-GRAPHQL
+      {
+        product(id: "1") {
+          id
+          nonNullButRaises
+        }
+      }
+    GRAPHQL
+    result = Schema.execute(query_string)
+    expected = { 'data' => { 'product' => nil }, 'errors' => [{ 'message' => 'Error', 'locations' => [{ 'line' => 4, 'column' => 11 }], 'path' => ['product', 'nonNullButRaises'] }] }
+    assert_equal expected, result
+  end
+
+  def test_non_null_field_that_raises_on_query_root
+    query_string = <<-GRAPHQL
+      {
+        nonNullButRaises {
+          id
+        }
+      }
+    GRAPHQL
+    result = Schema.execute(query_string)
+    expected = { 'data' => nil, 'errors' => [{ 'message' => 'Error', 'locations' => [{ 'line' => 2, 'column' => 9 }], 'path' => ['nonNullButRaises'] }] }
+    assert_equal expected, result
+  end
+
   def test_batched_association_preload
     query_string = <<-GRAPHQL
       {

--- a/test/support/schema.rb
+++ b/test/support/schema.rb
@@ -41,6 +41,13 @@ ProductType = GraphQL::ObjectType.define do
     }
   end
 
+  field :nonNullButRaises do
+    type !types.String
+    resolve -> (_, _, _) {
+      raise GraphQL::ExecutionError, 'Error'
+    }
+  end
+
   field :variants do
     type types[!ProductVariantType]
     resolve -> (product, args, ctx) {
@@ -69,6 +76,13 @@ QueryType = GraphQL::ObjectType.define do
       RecordLoader.for(Product).load(1).then do |product|
         raise GraphQL::ExecutionError, "test error message"
       end
+    }
+  end
+
+  field :nonNullButRaises do
+    type !ProductType
+    resolve -> (_, _, _) {
+      raise GraphQL::ExecutionError, 'Error'
     }
   end
 


### PR DESCRIPTION
re: rmosolgo/graphql-ruby#296 and closes #18 

This adds two regression tests for non-nullable fields that raise.

:eyes: @dylanahsmith 