### PR TITLE
Provide a useful error when load is called after perform

### DIFF
--- a/lib/graphql/batch/loader.rb
+++ b/lib/graphql/batch/loader.rb
@@ -22,6 +22,9 @@ module GraphQL::Batch
     end
 
     def load(key)
+      if promises_by_key.frozen?
+        raise "Loader can't be used after batch load"
+      end
       promises_by_key[key] ||= Promise.new
     end
 
@@ -43,6 +46,7 @@ module GraphQL::Batch
     end
 
     def resolve
+      promises_by_key.freeze
       perform(keys)
       check_for_broken_promises
     rescue => err

--- a/test/loader_test.rb
+++ b/test/loader_test.rb
@@ -112,4 +112,14 @@ class GraphQL::Batch::LoaderTest < Minitest::Test
     ])
     assert_equal [:a, 2], group.sync
   end
+
+  def test_load_after_perform
+    loader = EchoLoader.for
+    assert_equal :a, loader.load(:a).sync
+
+    err = assert_raises(RuntimeError) do
+      loader.load(:b).sync
+    end
+    assert_equal "Loader can't be used after batch load", err.message
+  end
 end


### PR DESCRIPTION
Fixes #21

@Mange what do you think about a runtime error of "Loader can't be used after batch load" to avoid confusion?