### PR TITLE
Fix handling ExecutionError in promise callback of non-null field

### DIFF
--- a/lib/graphql/batch/execution_strategy.rb
+++ b/lib/graphql/batch/execution_strategy.rb
@@ -1,7 +1,10 @@
 module GraphQL::Batch
   class ExecutionStrategy < GraphQL::Query::SerialExecution
-    def execute(_, _, _)
+    def execute(_, _, query)
       as_promise(super).sync
+    rescue GraphQL::InvalidNullError => err
+      err.parent_error? || query.context.errors.push(err)
+      nil
     ensure
       GraphQL::Batch::Executor.current.clear
     end

--- a/test/batch_test.rb
+++ b/test/batch_test.rb
@@ -106,6 +106,12 @@ class GraphQL::BatchTest < Minitest::Test
     assert_equal expected, result
   end
 
+  def test_non_null_field_promise_raises
+    result = Schema.execute('{ nonNullButPromiseRaises }')
+    expected = { 'data' => nil, 'errors' => [{ 'message' => 'Error', 'locations' => [{ 'line' => 1, 'column' => 3 }], 'path' => ['nonNullButPromiseRaises'] }] }
+    assert_equal expected, result
+  end
+
   def test_batched_association_preload
     query_string = <<-GRAPHQL
       {

--- a/test/support/loaders.rb
+++ b/test/support/loaders.rb
@@ -38,3 +38,13 @@ class CounterLoader < GraphQL::Batch::Loader
     keys.each { |key| fulfill(key, @hash[:counter][0]) }
   end
 end
+
+class NilLoader < GraphQL::Batch::Loader
+  def self.load
+    self.for.load(nil)
+  end
+
+  def perform(nils)
+    nils.each { |key| fulfill(nil, nil) }
+  end
+end

--- a/test/support/schema.rb
+++ b/test/support/schema.rb
@@ -86,6 +86,15 @@ QueryType = GraphQL::ObjectType.define do
     }
   end
 
+  field :nonNullButPromiseRaises do
+    type !types.String
+    resolve -> (_, _, _) {
+      NilLoader.load.then do
+        raise GraphQL::ExecutionError, 'Error'
+      end
+    }
+  end
+
   field :product do
     type ProductType
     argument :id, !types.ID


### PR DESCRIPTION
@cjoudrey & @eapache please review

## Problem

We were getting a `GraphQL::InvalidNullError: Cannot return null for non-nullable field` exception from a type check that was being done after preloading associations for a field in Shopify.  The type check was returning an GraphQL::ExecutionError, so the error should have been handled and serialized as part of the query result.

I was able to simplify the code to reproduce the bug down to this script

```ruby
require 'graphql/batch'

class EchoLoader < GraphQL::Batch::Loader
  def perform(keys)
    keys.each { |key| fulfill(key, key) }
  end
end

QueryType = GraphQL::ObjectType.define do
  name "Query"

  field :test, !types.String do
    resolve -> (obj, args, ctx) {
      EchoLoader.load(nil).then do
        raise GraphQL::ExecutionError, "test error"
      end
    }
  end
end

Schema = GraphQL::Schema.define do
  query QueryType
end
Schema.query_execution_strategy = GraphQL::Batch::ExecutionStrategy

puts Schema.execute('{ test }')
```

which should have output

```
{"data"=>nil, "errors"=>[{"message"=>"test error", "locations"=>[{"line"=>2, "column"=>3}], "path"=>["test"]}]}
```

but instead I got

```
/Users/dylansmith/.gem/ruby/2.3.1/gems/graphql-0.19.3/lib/graphql/query/serial_execution/value_resolution.rb:89:in `result': Cannot return null for non-nullable field Query.test (GraphQL::InvalidNullError)
	from /Users/dylansmith/.gem/ruby/2.3.1/gems/graphql-0.19.3/lib/graphql/query/serial_execution/field_resolution.rb:46:in `get_finished_value'
	from /Users/dylansmith/src/graphql-batch/lib/graphql/batch/execution_strategy.rb:53:in `block in get_finished_value'
	from /Users/dylansmith/.gem/ruby/2.3.1/gems/promise.rb-0.7.1/lib/promise/callback.rb:29:in `call_block'
	from /Users/dylansmith/.gem/ruby/2.3.1/gems/promise.rb-0.7.1/lib/promise/callback.rb:22:in `call'
	from /Users/dylansmith/.gem/ruby/2.3.1/gems/promise.rb-0.7.1/lib/promise.rb:121:in `block in dispatch!'
	from /Users/dylansmith/.gem/ruby/2.3.1/gems/promise.rb-0.7.1/lib/promise.rb:89:in `defer'
	from /Users/dylansmith/src/graphql-batch/lib/graphql/batch/promise.rb:8:in `block in defer'
	from /Users/dylansmith/src/graphql-batch/lib/graphql/batch/executor.rb:48:in `block in defer'
	from /Users/dylansmith/src/graphql-batch/lib/graphql/batch/executor.rb:57:in `with_loading'
	from /Users/dylansmith/src/graphql-batch/lib/graphql/batch/executor.rb:48:in `defer'
	from /Users/dylansmith/src/graphql-batch/lib/graphql/batch/promise.rb:8:in `defer'
	from /Users/dylansmith/.gem/ruby/2.3.1/gems/promise.rb-0.7.1/lib/promise.rb:121:in `dispatch!'
	from /Users/dylansmith/.gem/ruby/2.3.1/gems/promise.rb-0.7.1/lib/promise.rb:115:in `block in dispatch'
	from /Users/dylansmith/.gem/ruby/2.3.1/gems/promise.rb-0.7.1/lib/promise.rb:115:in `each'
	from /Users/dylansmith/.gem/ruby/2.3.1/gems/promise.rb-0.7.1/lib/promise.rb:115:in `dispatch'
	from /Users/dylansmith/.gem/ruby/2.3.1/gems/promise.rb-0.7.1/lib/promise.rb:82:in `reject'
	from /Users/dylansmith/.gem/ruby/2.3.1/gems/promise.rb-0.7.1/lib/promise/callback.rb:31:in `rescue in call_block'
	from /Users/dylansmith/.gem/ruby/2.3.1/gems/promise.rb-0.7.1/lib/promise/callback.rb:28:in `call_block'
	from /Users/dylansmith/.gem/ruby/2.3.1/gems/promise.rb-0.7.1/lib/promise/callback.rb:20:in `call'
	from /Users/dylansmith/.gem/ruby/2.3.1/gems/promise.rb-0.7.1/lib/promise.rb:121:in `block in dispatch!'
	from /Users/dylansmith/.gem/ruby/2.3.1/gems/promise.rb-0.7.1/lib/promise.rb:89:in `defer'
	from /Users/dylansmith/src/graphql-batch/lib/graphql/batch/promise.rb:8:in `block in defer'
	from /Users/dylansmith/src/graphql-batch/lib/graphql/batch/executor.rb:48:in `block in defer'
	from /Users/dylansmith/src/graphql-batch/lib/graphql/batch/executor.rb:57:in `with_loading'
	from /Users/dylansmith/src/graphql-batch/lib/graphql/batch/executor.rb:48:in `defer'
	from /Users/dylansmith/src/graphql-batch/lib/graphql/batch/promise.rb:8:in `defer'
	from /Users/dylansmith/.gem/ruby/2.3.1/gems/promise.rb-0.7.1/lib/promise.rb:121:in `dispatch!'
	from /Users/dylansmith/.gem/ruby/2.3.1/gems/promise.rb-0.7.1/lib/promise.rb:115:in `block in dispatch'
	from /Users/dylansmith/.gem/ruby/2.3.1/gems/promise.rb-0.7.1/lib/promise.rb:115:in `each'
	from /Users/dylansmith/.gem/ruby/2.3.1/gems/promise.rb-0.7.1/lib/promise.rb:115:in `dispatch'
	from /Users/dylansmith/.gem/ruby/2.3.1/gems/promise.rb-0.7.1/lib/promise.rb:73:in `fulfill'
	from /Users/dylansmith/src/graphql-batch/lib/graphql/batch/loader.rb:36:in `fulfill'
	from tmp/test.rb:5:in `block in perform'
	from tmp/test.rb:5:in `each'
	from tmp/test.rb:5:in `perform'
	from /Users/dylansmith/src/graphql-batch/lib/graphql/batch/loader.rb:50:in `resolve'
	from /Users/dylansmith/src/graphql-batch/lib/graphql/batch/executor.rb:27:in `block in tick'
	from /Users/dylansmith/src/graphql-batch/lib/graphql/batch/executor.rb:57:in `with_loading'
	from /Users/dylansmith/src/graphql-batch/lib/graphql/batch/executor.rb:27:in `tick'
	from /Users/dylansmith/src/graphql-batch/lib/graphql/batch/executor.rb:31:in `wait'
	from /Users/dylansmith/src/graphql-batch/lib/graphql/batch/promise.rb:4:in `wait'
	from /Users/dylansmith/.gem/ruby/2.3.1/gems/promise.rb-0.7.1/lib/promise.rb:64:in `sync'
	from /Users/dylansmith/src/graphql-batch/lib/graphql/batch/execution_strategy.rb:4:in `execute'
	from /Users/dylansmith/.gem/ruby/2.3.1/gems/graphql-0.19.3/lib/graphql/query/executor.rb:33:in `execute'
	from /Users/dylansmith/.gem/ruby/2.3.1/gems/graphql-0.19.3/lib/graphql/query/executor.rb:15:in `result'
	from /Users/dylansmith/.gem/ruby/2.3.1/gems/graphql-0.19.3/lib/graphql/query.rb:82:in `result'
	from /Users/dylansmith/.gem/ruby/2.3.1/gems/graphql-0.19.3/lib/graphql/schema.rb:134:in `execute'
	from tmp/test.rb:31:in `<main>'
```

## Solution

What was missing was that the rescue block in [GraphQL::Query::SerialExecution::OperationResolution#result](https://github.com/rmosolgo/graphql-ruby/blob/v0.19.3/lib/graphql/query/serial_execution/operation_resolution.rb#L20-L23) wasn't rescuing the InvalidNullError since GraphQL::Query::SerialExecution::SelectionResolution#result was returning a promise value that later gets rejected with the InvalidNullError.  This means we need to rescue the InvalidNullError in a similar way in GraphQL::Batch::ExecutionStrategy since that upstream rescue block was skipped.