### PR TITLE
Allow loaders to be re-used so they can cache loads.

### DIFF
--- a/test/loader_test.rb
+++ b/test/loader_test.rb
@@ -121,12 +121,10 @@ class GraphQL::Batch::LoaderTest < Minitest::Test
 
   def test_load_after_perform
     loader = EchoLoader.for
-    assert_equal :a, loader.load(:a).sync
-
-    err = assert_raises(RuntimeError) do
-      loader.load(:b).sync
-    end
-    assert_equal "Loader can't be used after batch load", err.message
+    promise1 = loader.load(:a)
+    assert_equal :a, promise1.sync
+    assert_equal :b, loader.load(:b).sync
+    assert_equal promise1, loader.load(:a)
   end
 
   def test_derived_cache_key

--- a/test/loader_test.rb
+++ b/test/loader_test.rb
@@ -127,6 +127,21 @@ class GraphQL::Batch::LoaderTest < Minitest::Test
     assert_equal promise1, loader.load(:a)
   end
 
+  def test_load_on_different_loaders
+    loader = EchoLoader.for
+    assert_equal :a, loader.load(:a).sync
+    loader2 = EchoLoader.for
+    promise = loader2.load(:b)
+
+    err = assert_raises(RuntimeError) do
+      loader.load(:c)
+    end
+
+    assert_equal "load called on loader that wasn't registered with executor", err.message
+    assert_equal :b, promise.sync
+    assert_equal :c, loader.load(:c).sync
+  end
+
   def test_derived_cache_key
     assert_equal [:a, :b, :a], DerivedCacheKeyLoader.load_many([:a, :b, "a"]).sync
   end


### PR DESCRIPTION
@cjoudrey & @xuorig please review
cc @Mange since you opened #21

This allows a loader to be re-used so that it can be used to cache previous loads.

Currently this will require keeping a reference to the loader to re-use it.  A follow-up will be needed to have the executor keep references to the old loaders during a GraphQL request.