### PR TITLE
refactor(MutationExecutionStrategy) don't switch strategies during resolution

### DIFF
--- a/lib/graphql/batch/mutation_execution_strategy.rb
+++ b/lib/graphql/batch/mutation_execution_strategy.rb
@@ -4,15 +4,10 @@ module GraphQL::Batch
       def get_finished_value(raw_value)
         raw_value = GraphQL::Batch::Promise.resolve(raw_value).sync
 
-        context = execution_context.query.context
-        old_execution_strategy = context.execution_strategy
         begin
-          context.execution_strategy = GraphQL::Batch::ExecutionStrategy.new
           result = super(raw_value)
           GraphQL::Batch::Executor.current.wait_all
           result
-        ensure
-          context.execution_strategy = old_execution_strategy
         end
       end
     end


### PR DESCRIPTION
I found that these lines don't make a difference in the test outcome ... are they used for something? 

I found this because I was refactoring SerialExecution in https://github.com/rmosolgo/graphql-ruby/pull/379. I switched from using `execution_context.strategy` (not reassigned in this code) to using `context.execution_strategy` (reassigned in this code). After the refactor, I ran the `graphql-batch` tests against my branch and got a failure: 

```
 1) Failure:
GraphQL::BatchTest#test_mutation_execution [/Users/rmosolgo/projects/graphql-batch/test/batch_test.rb:311]:
--- expected
+++ actual
@@ -1 +1 @@
-{"data"=>{"count1"=>0, "incr1"=>{"value"=>1, "load_value"=>1}, "count2"=>1, "incr2"=>{"value"=>2, "load_value"=>2}}}
+{"data"=>{"count1"=>0, "incr1"=>{"value"=>1, "load_value"=>#<GraphQL::Batch::Promise:0xXXXXXX @state=:fulfilled, @callbacks=[], @value=1>}, "count2"=>1, "incr2"=>{"value"=>2, "load_value"=>#<GraphQL::Batch::Promise:0xXXXXXX @state=:fulfilled, @callbacks=[], @value=2>}}}
```

I "fixed" the test by ignoring any assignments to `context.execution_strategy=` after the first (https://github.com/rmosolgo/graphql-ruby/pull/379/commits/497e628380edb47038b23e41b93708ba03e7a590). 

Sorry about these bugs from coupling 😩 hoping to take the execution-related concerns "in-house" soon! 