### PR TITLE
Fix resolving loader when Loader.for is used without load

### DIFF
--- a/lib/graphql/batch/loader.rb
+++ b/lib/graphql/batch/loader.rb
@@ -33,7 +33,8 @@ module GraphQL::Batch
     end
 
     def resolve #:nodoc:
-      load_keys = @queue
+      load_keys = queue
+      return if load_keys.empty?
       @queue = nil
       perform(load_keys)
       check_for_broken_promises(load_keys)

--- a/test/loader_test.rb
+++ b/test/loader_test.rb
@@ -145,4 +145,9 @@ class GraphQL::Batch::LoaderTest < Minitest::Test
   def test_derived_cache_key
     assert_equal [:a, :b, :a], DerivedCacheKeyLoader.load_many([:a, :b, "a"]).sync
   end
+
+  def test_loader_for_without_load
+    loader = EchoLoader.for
+    GraphQL::Batch::Executor.current.wait_all
+  end
 end


### PR DESCRIPTION
@cjoudrey, @xuorig

I tried to bump graphql-batch in Shopify to use the latest commit on master and got an exception that I reproduced with the added regression test.

```
GraphQL::Batch::LoaderTest#test_loader_for_without_load:
NoMethodError: undefined method `each' for nil:NilClass
    /Users/dylansmith/src/graphql-batch/lib/graphql/batch/loader.rb:83:in `each_pending_promise'
    /Users/dylansmith/src/graphql-batch/lib/graphql/batch/loader.rb:41:in `rescue in resolve'
    /Users/dylansmith/src/graphql-batch/lib/graphql/batch/loader.rb:36:in `resolve'
    /Users/dylansmith/src/graphql-batch/lib/graphql/batch/executor.rb:27:in `block in tick'
    /Users/dylansmith/src/graphql-batch/lib/graphql/batch/executor.rb:57:in `with_loading'
    /Users/dylansmith/src/graphql-batch/lib/graphql/batch/executor.rb:27:in `tick'
    /Users/dylansmith/src/graphql-batch/lib/graphql/batch/executor.rb:38:in `wait_all'
    /Users/dylansmith/src/graphql-batch/test/loader_test.rb:151:in `test_loader_for_without_load'
```

The problem is that `@queue` is used directly in GraphQL::Batch::Loader#resolve, but it may be `nil` if nothing was added to the queue, since it is lazily initialized to an array in the `queue` accessor method.

This as happening in Shopify because we override GraphQL::Batch::Loader#load for our AssociationLoader to return a resolved promise if the association is already loaded on the record, so AssociationLoader.for gets called, which registers the loader with the executor, without anything being added to the queue on the returned loader.

This PR simply returns early in GraphQL::Batch::Loader#resolve if the queue is empty.