### PR TITLE
Fix batching loading in mutation subselection

### DIFF
--- a/lib/graphql/batch/execution_strategy.rb
+++ b/lib/graphql/batch/execution_strategy.rb
@@ -1,5 +1,7 @@
 module GraphQL::Batch
   class ExecutionStrategy < GraphQL::Query::SerialExecution
+    attr_accessor :disable_batching
+
     def execute(_, _, query)
       as_promise(super).sync
     rescue GraphQL::InvalidNullError => err

--- a/test/support/schema.rb
+++ b/test/support/schema.rb
@@ -142,6 +142,10 @@ MutationType = GraphQL::ObjectType.define do
   field :counter_loader, !types.Int do
     resolve ->(_, _, ctx) { CounterLoader.for(ctx).load }
   end
+
+  field :no_op, !QueryType do
+    resolve ->(_, _, ctx) { Hash.new }
+  end
 end
 
 Schema = GraphQL::Schema.define do


### PR DESCRIPTION
Closes #30

@rmosolgo I added a regression test for the broken code you tried to remove in #30 and fixed it without swapping the execution strategy

@xuorig & @cjoudrey looks like our batching has been broken for mutations subselections which this fixes