### PR TITLE
Take advantage of improvements in promise.rb

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,26 +109,13 @@ end
 
 ## Unit Testing
 
-GraphQL::Batch::Promise#sync can be used to wait for a promise to be resolved and return its result. This can be useful for debugging and unit testing loaders.
+Promise#sync can be used to wait for a promise to be resolved and return its result. This can be useful for debugging and unit testing loaders.
 
 ```ruby
   def test_single_query
     product = products(:snowboard)
     query = RecordLoader.for(Product).load(args["id"]).then(&:title)
     assert_equal product.title, query.sync
-  end
-```
-
-Use GraphQL::Batch::Promise.all instead of Promise.all to be able to call sync on the returned promise.
-
-```ruby
-  def test_batch_query
-    products = [products(:snowboard), products(:jacket)]
-    query1 = RecordLoader.for(Product).load(products(:snowboard).id).then(&:title)
-    query2 = RecordLoader.for(Product).load(products(:jacket).id).then(&:title)
-    results = GraphQL::Batch::Promise.all([query1, query2]).sync
-    assert_equal products(:snowboard).title, results[0]
-    assert_equal products(:jacket).title, results[1]
   end
 ```
 

--- a/graphql-batch.gemspec
+++ b/graphql-batch.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "graphql", ">= 0.8", "< 2"
-  spec.add_runtime_dependency "promise.rb", "~> 0.7.0.rc2"
+  spec.add_runtime_dependency "promise.rb", "~> 0.7.2"
 
   spec.add_development_dependency "byebug" if RUBY_ENGINE == 'ruby'
   spec.add_development_dependency "bundler", "~> 1.10"

--- a/lib/graphql/batch.rb
+++ b/lib/graphql/batch.rb
@@ -3,7 +3,7 @@ require "promise.rb"
 
 module GraphQL
   module Batch
-    BrokenPromiseError = Promise::BrokenError
+    BrokenPromiseError = ::Promise::BrokenError
   end
 end
 

--- a/lib/graphql/batch.rb
+++ b/lib/graphql/batch.rb
@@ -3,7 +3,7 @@ require "promise.rb"
 
 module GraphQL
   module Batch
-    BrokenPromiseError = Class.new(StandardError)
+    BrokenPromiseError = Promise::BrokenError
   end
 end
 

--- a/lib/graphql/batch/execution_strategy.rb
+++ b/lib/graphql/batch/execution_strategy.rb
@@ -3,7 +3,7 @@ module GraphQL::Batch
     attr_accessor :disable_batching
 
     def execute(_, _, query)
-      as_promise(super).sync
+      Promise.sync(as_promise_unless_resolved(super))
     rescue GraphQL::InvalidNullError => err
       err.parent_error? || query.context.errors.push(err)
       nil
@@ -12,10 +12,6 @@ module GraphQL::Batch
     end
 
     private
-
-    def as_promise(result)
-      GraphQL::Batch::Promise.resolve(as_promise_unless_resolved(result))
-    end
 
     def as_promise_unless_resolved(result)
       all_promises = []

--- a/lib/graphql/batch/executor.rb
+++ b/lib/graphql/batch/executor.rb
@@ -30,7 +30,7 @@ module GraphQL::Batch
     def wait(promise)
       tick while promise.pending? && !loaders.empty?
       if promise.pending?
-        promise.reject(BrokenPromiseError.new("Promise wasn't fulfilled after all queries were loaded"))
+        promise.reject(::Promise::BrokenError.new("Promise wasn't fulfilled after all queries were loaded"))
       end
     end
 

--- a/lib/graphql/batch/loader.rb
+++ b/lib/graphql/batch/loader.rb
@@ -91,7 +91,7 @@ module GraphQL::Batch
 
     def check_for_broken_promises(load_keys)
       each_pending_promise(load_keys) do |key, promise|
-        promise.reject(BrokenPromiseError.new("#{self.class} didn't fulfill promise for key #{key.inspect}"))
+        promise.reject(::Promise::BrokenError.new("#{self.class} didn't fulfill promise for key #{key.inspect}"))
       end
     end
   end

--- a/test/loader_test.rb
+++ b/test/loader_test.rb
@@ -44,7 +44,7 @@ class GraphQL::Batch::LoaderTest < Minitest::Test
   end
 
   def test_query_group
-    group = GraphQL::Batch::Promise.all([
+    group = Promise.all([
       GroupCountLoader.for('two').load(:a),
       GroupCountLoader.for('one').load(:a),
       GroupCountLoader.for('two').load(:b),
@@ -57,15 +57,15 @@ class GraphQL::Batch::LoaderTest < Minitest::Test
   end
 
   def test_empty_group_query
-    assert_equal [], GraphQL::Batch::Promise.all([]).sync
+    assert_equal [], Promise.all([]).sync
   end
 
   def test_group_query_with_non_queries
-    assert_equal [1, :a, 'b'], GraphQL::Batch::Promise.all([1, :a, 'b']).sync
+    assert_equal [1, :a, 'b'], Promise.all([1, :a, 'b']).sync
   end
 
   def test_group_query_with_some_queries
-    group = GraphQL::Batch::Promise.all([
+    group = Promise.all([
       GroupCountLoader.for("two").load(:a),
       'one',
       GroupCountLoader.for("two").load(:b),
@@ -112,7 +112,7 @@ class GraphQL::Batch::LoaderTest < Minitest::Test
   end
 
   def test_loader_class_grouping
-    group = GraphQL::Batch::Promise.all([
+    group = Promise.all([
       EchoLoader.load(:a),
       IncrementLoader.load(1),
     ])


### PR DESCRIPTION
@rmosolgo @xuorig

promise.rb 0.7.2 now supports `.sync` being called on the result of Promise.all, so we don't need to warn about that in the README.

Also, in the next version of graphql-ruby we can use `lazy_resolve(Promise, :sync)` in the Schema without the need to use GraphQL::Batch::Promise.all in resolve methods.

I have also tested this PR with the following changes to test with the graphql-ruby lazy resolution API

```diff
diff --git a/Gemfile b/Gemfile
index fa75df1..a7f313a 100644
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
 source 'https://rubygems.org'

 gemspec
+
+gem 'graphql', github: 'rmosolgo/graphql-ruby', branch: 'master'
diff --git a/test/support/schema.rb b/test/support/schema.rb
index dfaa799..238b4ac 100644
--- a/test/support/schema.rb
+++ b/test/support/schema.rb
@@ -151,6 +151,5 @@ end
 Schema = GraphQL::Schema.define do
   query QueryType
   mutation MutationType
-  query_execution_strategy GraphQL::Batch::ExecutionStrategy
-  mutation_execution_strategy GraphQL::Batch::MutationExecutionStrategy
+  lazy_resolve(Promise, :sync)
```