### PR TITLE
Allow loaders to be used without an executor

### DIFF
--- a/lib/graphql/batch/execution_strategy.rb
+++ b/lib/graphql/batch/execution_strategy.rb
@@ -1,12 +1,16 @@
 module GraphQL::Batch
   class ExecutionStrategy < GraphQL::Query::SerialExecution
     def execute(_, _, query)
-      Promise.sync(as_promise_unless_resolved(super))
+      deep_sync(super)
     rescue GraphQL::InvalidNullError => err
       err.parent_error? || query.context.errors.push(err)
       nil
     ensure
       GraphQL::Batch::Executor.current.clear
+    end
+
+    def deep_sync(result)
+      Promise.sync(as_promise_unless_resolved(result))
     end
 
     private

--- a/lib/graphql/batch/execution_strategy.rb
+++ b/lib/graphql/batch/execution_strategy.rb
@@ -21,7 +21,7 @@ module GraphQL::Batch
         end
       end
       return result if all_promises.empty?
-      Promise.all(all_promises).then { result }
+      ::Promise.all(all_promises).then { result }
     end
 
     def each_promise(obj, &block)

--- a/lib/graphql/batch/executor.rb
+++ b/lib/graphql/batch/executor.rb
@@ -19,19 +19,16 @@ module GraphQL::Batch
       @loading = false
     end
 
+    def resolve(loader)
+      with_loading(true) { loader.resolve }
+    end
+
     def shift
       @loaders.shift.last
     end
 
     def tick
-      with_loading(true) { shift.resolve }
-    end
-
-    def wait(promise)
-      tick while promise.pending? && !loaders.empty?
-      if promise.pending?
-        promise.reject(::Promise::BrokenError.new("Promise wasn't fulfilled after all queries were loaded"))
-      end
+      resolve(shift)
     end
 
     def wait_all

--- a/lib/graphql/batch/mutation_execution_strategy.rb
+++ b/lib/graphql/batch/mutation_execution_strategy.rb
@@ -4,17 +4,14 @@ module GraphQL::Batch
 
     class FieldResolution < GraphQL::Batch::ExecutionStrategy::FieldResolution
       def get_finished_value(raw_value)
-        return super if execution_context.strategy.enable_batching
+        strategy = execution_context.strategy
+        return super if strategy.enable_batching
 
-        raw_value = Promise.sync(raw_value)
-
-        execution_context.strategy.enable_batching = true
         begin
-          result = super(raw_value)
-          GraphQL::Batch::Executor.current.wait_all
-          Promise.sync(result)
+          strategy.enable_batching = true
+          strategy.deep_sync(Promise.sync(super))
         ensure
-          execution_context.strategy.enable_batching = false
+          strategy.enable_batching = false
         end
       end
     end

--- a/lib/graphql/batch/mutation_execution_strategy.rb
+++ b/lib/graphql/batch/mutation_execution_strategy.rb
@@ -12,7 +12,7 @@ module GraphQL::Batch
         begin
           result = super(raw_value)
           GraphQL::Batch::Executor.current.wait_all
-          result
+          Promise.sync(result)
         ensure
           execution_context.strategy.enable_batching = false
         end

--- a/lib/graphql/batch/promise.rb
+++ b/lib/graphql/batch/promise.rb
@@ -1,11 +1,8 @@
 module GraphQL::Batch
   class Promise < ::Promise
-    def wait
-      Executor.current.wait(self)
-    end
-
     def defer
-      Executor.current.defer { super }
+      executor = Executor.current
+      executor ? executor.defer { super } : super
     end
   end
 end


### PR DESCRIPTION
@rmosolgo, @xuorig & @cjoudrey 

## Problem

As pointed out in https://github.com/Shopify/graphql-batch/pull/33#discussion_r88349952, when using graphql-batch outside of the execution strategy, we run the risk of leaky state.  This could be a problem when using the graphql gem's new lazy resolution API, but it could also be a problem in tests.

As such, I think we should move away from depending on global state, even if we support one for convenience and backwards compatibility.

The thread local executor is used for three purposes right now:
1. stores a list of loaders
2. executes those loaders
3. keeps track of the loading flag that unit tests can check to catch unbatched queries

## Solution

promise.rb 0.7.2 now keeps track of the source of the promise and uses that to sync the promise by default.  All that is needed to use that is to set the promise source on the promise returned by the loader's load method.

Without the need to use the executor for resolve the promises, we could then create per request loaders as documented in the [dataloader README](https://github.com/facebook/dataloader#creating-a-new-dataloader-per-request) which could then be stored in the graphql query context.  Doing this also allows loaders' cache to be used after their batch load is performed.  However, this does bring the concern of cache invalidation if the loaders are used across top-level mutation fields.

For now the loading flag is kept on the executor and is just not updated when there is no current executor.  That could be fixed in the future by moving the flag outside of the executor into it's own thread-local variable, but will more likely be replaced by a more generic instrumentation hook.

## Follow-up

I plan on having the executor not get created automatically and require the code using the library to specify where batching starts and stops using a block.  E.g.

```ruby
product = GraphQL::Batch.batch do
    RecordLoader.for(Product).load(product_id)
end
```

would setup the executor for the block and pass the result of the block to `Promise.sync`