### PR TITLE
Support graphql-ruby lazy resolution API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 /.bundle/
 /.yardoc
-/Gemfile.lock
+/Gemfile*.lock
 /_yardoc/
 /coverage/
 /doc/

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,7 @@ language: ruby
 rvm:
   - 2.1
   - 2.2
-before_install: gem install bundler -v 1.11.2
+gemfile:
+  - Gemfile
+  - Gemfile.graphql13
+before_install: gem install bundler -v 1.13.3

--- a/Gemfile.graphql13
+++ b/Gemfile.graphql13
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gemspec
+
+gem 'graphql', github: 'rmosolgo/graphql-ruby', branch: 'master'

--- a/lib/graphql/batch.rb
+++ b/lib/graphql/batch.rb
@@ -22,5 +22,10 @@ require_relative "batch/version"
 require_relative "batch/loader"
 require_relative "batch/executor"
 require_relative "batch/promise"
-require_relative "batch/execution_strategy"
-require_relative "batch/mutation_execution_strategy"
+require_relative "batch/setup"
+
+# Allow custom execution strategies to be removed upstream
+if defined?(GraphQL::Query::SerialExecution)
+  require_relative "batch/execution_strategy"
+  require_relative "batch/mutation_execution_strategy"
+end

--- a/lib/graphql/batch/setup.rb
+++ b/lib/graphql/batch/setup.rb
@@ -1,0 +1,14 @@
+module GraphQL::Batch
+  module Setup
+    extend self
+
+    def before_query(query)
+      raise NestedError if GraphQL::Batch::Executor.current
+      GraphQL::Batch::Executor.current = GraphQL::Batch::Executor.new
+    end
+
+    def after_query(query)
+      GraphQL::Batch::Executor.current = nil
+    end
+  end
+end

--- a/test/graphql_test.rb
+++ b/test/graphql_test.rb
@@ -12,9 +12,13 @@ class GraphQL::GraphQLTest < Minitest::Test
     QueryNotifier.subscriber = nil
   end
 
+  def schema
+    ::Schema
+  end
+
   def test_no_queries
     query_string = '{ constant }'
-    result = Schema.execute(query_string)
+    result = schema.execute(query_string)
     expected = {
       "data" => {
         "constant" => "constant value"
@@ -33,7 +37,7 @@ class GraphQL::GraphQLTest < Minitest::Test
         }
       }
     GRAPHQL
-    result = Schema.execute(query_string)
+    result = schema.execute(query_string)
     expected = {
       "data" => {
         "product" => {
@@ -53,7 +57,7 @@ class GraphQL::GraphQLTest < Minitest::Test
         product2: product(id: "2") { id, title }
       }
     GRAPHQL
-    result = Schema.execute(query_string)
+    result = schema.execute(query_string)
     expected = {
       "data" => {
         "product1" => { "id" => "1", "title" => "Shirt" },
@@ -73,7 +77,7 @@ class GraphQL::GraphQLTest < Minitest::Test
         }
       }
     GRAPHQL
-    result = Schema.execute(query_string)
+    result = schema.execute(query_string)
     expected = { "data" => { "product" => nil } }
     assert_equal expected, result
     assert_equal ["Product/123"], queries
@@ -88,7 +92,7 @@ class GraphQL::GraphQLTest < Minitest::Test
         }
       }
     GRAPHQL
-    result = Schema.execute(query_string)
+    result = schema.execute(query_string)
     expected = { 'data' => { 'product' => nil }, 'errors' => [{ 'message' => 'Error', 'locations' => [{ 'line' => 4, 'column' => 11 }], 'path' => ['product', 'nonNullButRaises'] }] }
     assert_equal expected, result
   end
@@ -101,13 +105,13 @@ class GraphQL::GraphQLTest < Minitest::Test
         }
       }
     GRAPHQL
-    result = Schema.execute(query_string)
+    result = schema.execute(query_string)
     expected = { 'data' => nil, 'errors' => [{ 'message' => 'Error', 'locations' => [{ 'line' => 2, 'column' => 9 }], 'path' => ['nonNullButRaises'] }] }
     assert_equal expected, result
   end
 
   def test_non_null_field_promise_raises
-    result = Schema.execute('{ nonNullButPromiseRaises }')
+    result = schema.execute('{ nonNullButPromiseRaises }')
     expected = { 'data' => nil, 'errors' => [{ 'message' => 'Error', 'locations' => [{ 'line' => 1, 'column' => 3 }], 'path' => ['nonNullButPromiseRaises'] }] }
     assert_equal expected, result
   end
@@ -125,7 +129,7 @@ class GraphQL::GraphQLTest < Minitest::Test
         }
       }
     GRAPHQL
-    result = Schema.execute(query_string)
+    result = schema.execute(query_string)
     expected = {
       "data" => {
         "products" => [
@@ -167,7 +171,7 @@ class GraphQL::GraphQLTest < Minitest::Test
         }
       }
     GRAPHQL
-    result = Schema.execute(query_string)
+    result = schema.execute(query_string)
     expected = {
       "data" => {
         "products" => [
@@ -203,7 +207,7 @@ class GraphQL::GraphQLTest < Minitest::Test
         product_variants_count(id: "2")
       }
     GRAPHQL
-    result = Schema.execute(query_string)
+    result = schema.execute(query_string)
     expected = {
       "data" => {
         "product_variants_count" => 3
@@ -221,7 +225,7 @@ class GraphQL::GraphQLTest < Minitest::Test
         }
       }
     GRAPHQL
-    result = Schema.execute(query_string)
+    result = schema.execute(query_string)
     expected = {
       "data" => {
         "product" => {
@@ -249,7 +253,7 @@ class GraphQL::GraphQLTest < Minitest::Test
         }
       }
     GRAPHQL
-    result = Schema.execute(query_string)
+    result = schema.execute(query_string)
     expected = {
       "data" => {
         "products" => [
@@ -282,7 +286,7 @@ class GraphQL::GraphQLTest < Minitest::Test
         load_execution_error
       }
     GRAPHQL
-    result = Schema.execute(query_string)
+    result = schema.execute(query_string)
     expected = {
       "data" => { "constant"=>"constant value", "load_execution_error" => nil },
       "errors" => [{ "message" => "test error message", "locations"=>[{"line"=>3, "column"=>9}], "path" => ["load_execution_error"] }],
@@ -299,7 +303,7 @@ class GraphQL::GraphQLTest < Minitest::Test
         incr2: increment_counter { value, load_value }
       }
     GRAPHQL
-    result = Schema.execute(query_string, context: { counter: [0] })
+    result = schema.execute(query_string, context: { counter: [0] })
     expected = {
       "data" => {
         "count1" => 0,
@@ -324,7 +328,7 @@ class GraphQL::GraphQLTest < Minitest::Test
         }
       }
     GRAPHQL
-    result = Schema.execute(query_string)
+    result = schema.execute(query_string)
     expected = {
       "data" => {
         "mutation1" => {

--- a/test/lazy_resolve_test.rb
+++ b/test/lazy_resolve_test.rb
@@ -1,5 +1,6 @@
 require_relative 'graphql_test'
 
+# Feature detection to only run these tests against graphql-ruby master
 has_lazy_resolve = nil
 GraphQL::Schema.define do
   has_lazy_resolve = respond_to?(:lazy_resolve)

--- a/test/lazy_resolve_test.rb
+++ b/test/lazy_resolve_test.rb
@@ -1,0 +1,21 @@
+require_relative 'graphql_test'
+
+has_lazy_resolve = nil
+GraphQL::Schema.define do
+  has_lazy_resolve = respond_to?(:lazy_resolve)
+end
+
+if has_lazy_resolve
+  class GraphQL::LazyResolveTest < GraphQL::GraphQLTest
+    LazyResolveSchema = GraphQL::Schema.define do
+      query QueryType
+      mutation MutationType
+      lazy_resolve(Promise, :sync)
+      instrument(:query, GraphQL::Batch::Setup)
+    end
+
+    def schema
+      LazyResolveSchema
+    end
+  end
+end


### PR DESCRIPTION
@rmosolgo
cc @cjoudrey & @xuorig 

This should support both the new lazy resolution API that will come in graphql-ruby 1.3.0 as well as the old execution strategy, while also not breaking when the execution strategies are removed.

Nothing in this PR is specific to graphql-ruby 1.3.0 other than test/lazy_resolve_test.rb which uses feature detection to only run the test if the lazy_resolve method is defined, so we should be able to make a graphql-batch 0.3.0 release without waiting for graphql-ruby 1.3.0