### PR TITLE
No executor error

### DIFF
--- a/lib/graphql/batch/loader.rb
+++ b/lib/graphql/batch/loader.rb
@@ -1,8 +1,17 @@
 module GraphQL::Batch
   class Loader
+    class NoExecutorError < StandardError; end
+
     def self.for(*group_args)
       loader_key = [self].concat(group_args)
       executor = Executor.current
+
+      unless executor
+        raise NoExecutorError, "Cannot create loader without an Executor."\
+          " Wrap the call to `for` with `GraphQL::Batch.batch` or use"\
+          " `GraphQL::Batch::Setup` as a query instrumenter if using with `graphql-ruby`"
+      end
+
       executor.loaders[loader_key] ||= new(*group_args).tap do |loader|
         loader.loader_key = loader_key
         loader.executor = executor

--- a/test/loader_test.rb
+++ b/test/loader_test.rb
@@ -41,6 +41,14 @@ class GraphQL::Batch::LoaderTest < Minitest::Test
     GraphQL::Batch::Executor.current = nil
   end
 
+  def test_no_executor
+    GraphQL::Batch::Executor.current = nil
+
+    assert_raises(GraphQL::Batch::Loader::NoExecutorError) do
+      EchoLoader.for
+    end
+  end
+
   def test_single_query
     assert_equal 1, GroupCountLoader.for('single').load('first').sync
   end

--- a/test/loader_test.rb
+++ b/test/loader_test.rb
@@ -41,7 +41,6 @@ class GraphQL::Batch::LoaderTest < Minitest::Test
     GraphQL::Batch::Executor.current = nil
   end
 
-
   def test_single_query
     assert_equal 1, GroupCountLoader.for('single').load('first').sync
   end


### PR DESCRIPTION
Forgetting to use `GraphQL::Batch.batch`, or to use the Setup instrumenter when using graphql-ruby results in a `NoMethodError: undefined method `loaders' for nil:NilClass`.

Would be pretty useful to display a good error message there, wdyt ?