### PR TITLE
Expose `use_graphql_batch` instead of internal setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,7 @@ Use lazy execution and instrumentation by `GraphQL::Batch` in your schema
 MySchema = GraphQL::Schema.define do
   query MyQueryType
 
-  lazy_resolve(Promise, :sync)
-  instrument(:query, GraphQL::Batch::Setup)
+  use_graphql_batch
 end
 ```
 

--- a/lib/graphql/batch/execution_strategy.rb
+++ b/lib/graphql/batch/execution_strategy.rb
@@ -1,4 +1,4 @@
-warn "GraphQL::Batch::ExecutionStrategy is deprecated, instead use `lazy_resolve(Promise, :sync)` and `instrument(:query, GraphQL::Batch::Setup)` in GraphQL::Schema.define"
+warn "GraphQL::Batch::ExecutionStrategy is deprecated, instead use `use_graphql_batch` in `GraphQL::Schema.define`"
 
 module GraphQL::Batch
   class ExecutionStrategy < GraphQL::Query::SerialExecution

--- a/lib/graphql/batch/setup.rb
+++ b/lib/graphql/batch/setup.rb
@@ -12,3 +12,12 @@ module GraphQL::Batch
     end
   end
 end
+
+GraphQL::Schema.accepts_definitions(
+  use_graphql_batch: ->(schema) {
+    return if schema.metadata[:graphql_batch_setup]
+    schema.instrument(:query, GraphQL::Batch::Setup)
+    schema.lazy_methods.set(Promise, :sync)
+    schema.metadata[:graphql_batch_setup] = true
+  }
+)

--- a/test/support/schema.rb
+++ b/test/support/schema.rb
@@ -152,6 +152,5 @@ Schema = GraphQL::Schema.define do
   query QueryType
   mutation MutationType
 
-  lazy_resolve(Promise, :sync)
-  instrument(:query, GraphQL::Batch::Setup)
+  use_graphql_batch
 end


### PR DESCRIPTION
👋 @dylanahsmith @xuorig @rmosolgo

The setup instruction for `graphql-batch` kind of bugged me.

It felt as if we were exposing implementation details. Also, what happens if we ever need to change these instructions for whatever reason? It would be a shame to have to include "upgrade instructions" in the `README.md`.

I propose we hide these setup methods in the library and only expose an idempotent `use_graphql_batch` method in the `GraphQL::Schema` DSL.

Thoughts?