### PR TITLE
Make GraphQL::Batch a plugin by adding `use`

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,14 +46,23 @@ class RecordLoader < GraphQL::Batch::Loader
 end
 ```
 
-Use lazy execution and instrumentation by `GraphQL::Batch` in your schema
+Use `GraphQL::Batch` as a plugin in your schema (for graphql >= `1.5.0`).
 
 ```ruby
 MySchema = GraphQL::Schema.define do
   query MyQueryType
 
-  lazy_resolve(Promise, :sync)
-  instrument(:query, GraphQL::Batch::Setup)
+  use GraphQL::Batch
+end
+```
+
+For pre `1.5.0` versions:
+
+```ruby
+MySchema = GraphQL::Schema.define do
+  query MyQueryType
+
+  GraphQL::Batch.use(self)
 end
 ```
 

--- a/lib/graphql/batch.rb
+++ b/lib/graphql/batch.rb
@@ -19,6 +19,11 @@ module GraphQL
       end
     end
 
+    def self.use(schema_defn)
+      schema_defn.instrument(:query, GraphQL::Batch::Setup)
+      schema_defn.lazy_resolve(::Promise, :sync)
+    end
+
     autoload :ExecutionStrategy, 'graphql/batch/execution_strategy'
     autoload :MutationExecutionStrategy, 'graphql/batch/mutation_execution_strategy'
   end

--- a/lib/graphql/batch/execution_strategy.rb
+++ b/lib/graphql/batch/execution_strategy.rb
@@ -1,4 +1,4 @@
-warn "GraphQL::Batch::ExecutionStrategy is deprecated, instead use `lazy_resolve(Promise, :sync)` and `instrument(:query, GraphQL::Batch::Setup)` in GraphQL::Schema.define"
+warn "GraphQL::Batch::ExecutionStrategy is deprecated, instead add `use GraphQL::Batch` in GraphQL::Schema.define"
 
 module GraphQL::Batch
   class ExecutionStrategy < GraphQL::Query::SerialExecution

--- a/test/support/schema.rb
+++ b/test/support/schema.rb
@@ -152,6 +152,5 @@ Schema = GraphQL::Schema.define do
   query QueryType
   mutation MutationType
 
-  lazy_resolve(Promise, :sync)
-  instrument(:query, GraphQL::Batch::Setup)
+  use GraphQL::Batch
 end


### PR DESCRIPTION
Adds the `use` method so `GraphQL::Batch` can be used as a plugin in `define` blocks.

This replaces https://github.com/Shopify/graphql-batch/pull/49

/cc @cjoudrey