### PR TITLE
Improve loader reuse

### DIFF
--- a/lib/graphql/batch/loader.rb
+++ b/lib/graphql/batch/loader.rb
@@ -40,8 +40,8 @@ module GraphQL::Batch
     end
 
     def resolve #:nodoc:
+      return if resolved?
       load_keys = queue
-      return if load_keys.empty?
       @queue = nil
       perform(load_keys)
       check_for_broken_promises(load_keys)
@@ -54,11 +54,14 @@ module GraphQL::Batch
     # For Promise#sync
     def wait #:nodoc:
       if executor
-        executor.loaders.delete(loader_key)
         executor.resolve(self)
       else
         resolve
       end
+    end
+
+    def resolved?
+      @queue.nil? || @queue.empty?
     end
 
     protected

--- a/test/graphql_test.rb
+++ b/test/graphql_test.rb
@@ -342,6 +342,6 @@ class GraphQL::GraphQLTest < Minitest::Test
       }
     }
     assert_equal expected, result
-    assert_equal ["Product/1,2", "Product/2,3"], queries
+    assert_equal ["Product/1,2", "Product/3"], queries
   end
 end


### PR DESCRIPTION
Stop deleting loaders from the cache.

This improves loader reuse.