### PR TITLE
Fix tests for execution strategies

### DIFF
--- a/test/execution_strategy_test.rb
+++ b/test/execution_strategy_test.rb
@@ -9,7 +9,13 @@ class GraphQL::ExecutionStrategyTest < GraphQL::GraphQLTest
     mutation_execution_strategy GraphQL::Batch::MutationExecutionStrategy
   end
 
-  def schema
-    LegacySchema
+  class ExecutorWithSilencedWarn < GraphQL::Query::Executor
+    def warn(message)
+    end
+  end
+
+  def schema_execute(query_string, **kwargs)
+    query = GraphQL::Query.new(LegacySchema, query_string, **kwargs)
+    ExecutorWithSilencedWarn.new(query).result
   end
 end

--- a/test/graphql_test.rb
+++ b/test/graphql_test.rb
@@ -12,13 +12,13 @@ class GraphQL::GraphQLTest < Minitest::Test
     QueryNotifier.subscriber = nil
   end
 
-  def schema
-    ::Schema
+  def schema_execute(query_string, **kwargs)
+    ::Schema.execute(query_string, **kwargs)
   end
 
   def test_no_queries
     query_string = '{ constant }'
-    result = schema.execute(query_string)
+    result = schema_execute(query_string)
     expected = {
       "data" => {
         "constant" => "constant value"
@@ -37,7 +37,7 @@ class GraphQL::GraphQLTest < Minitest::Test
         }
       }
     GRAPHQL
-    result = schema.execute(query_string)
+    result = schema_execute(query_string)
     expected = {
       "data" => {
         "product" => {
@@ -57,7 +57,7 @@ class GraphQL::GraphQLTest < Minitest::Test
         product2: product(id: "2") { id, title }
       }
     GRAPHQL
-    result = schema.execute(query_string)
+    result = schema_execute(query_string)
     expected = {
       "data" => {
         "product1" => { "id" => "1", "title" => "Shirt" },
@@ -77,7 +77,7 @@ class GraphQL::GraphQLTest < Minitest::Test
         }
       }
     GRAPHQL
-    result = schema.execute(query_string)
+    result = schema_execute(query_string)
     expected = { "data" => { "product" => nil } }
     assert_equal expected, result
     assert_equal ["Product/123"], queries
@@ -92,7 +92,7 @@ class GraphQL::GraphQLTest < Minitest::Test
         }
       }
     GRAPHQL
-    result = schema.execute(query_string)
+    result = schema_execute(query_string)
     expected = { 'data' => { 'product' => nil }, 'errors' => [{ 'message' => 'Error', 'locations' => [{ 'line' => 4, 'column' => 11 }], 'path' => ['product', 'nonNullButRaises'] }] }
     assert_equal expected, result
   end
@@ -105,13 +105,13 @@ class GraphQL::GraphQLTest < Minitest::Test
         }
       }
     GRAPHQL
-    result = schema.execute(query_string)
+    result = schema_execute(query_string)
     expected = { 'data' => nil, 'errors' => [{ 'message' => 'Error', 'locations' => [{ 'line' => 2, 'column' => 9 }], 'path' => ['nonNullButRaises'] }] }
     assert_equal expected, result
   end
 
   def test_non_null_field_promise_raises
-    result = schema.execute('{ nonNullButPromiseRaises }')
+    result = schema_execute('{ nonNullButPromiseRaises }')
     expected = { 'data' => nil, 'errors' => [{ 'message' => 'Error', 'locations' => [{ 'line' => 1, 'column' => 3 }], 'path' => ['nonNullButPromiseRaises'] }] }
     assert_equal expected, result
   end
@@ -129,7 +129,7 @@ class GraphQL::GraphQLTest < Minitest::Test
         }
       }
     GRAPHQL
-    result = schema.execute(query_string)
+    result = schema_execute(query_string)
     expected = {
       "data" => {
         "products" => [
@@ -171,7 +171,7 @@ class GraphQL::GraphQLTest < Minitest::Test
         }
       }
     GRAPHQL
-    result = schema.execute(query_string)
+    result = schema_execute(query_string)
     expected = {
       "data" => {
         "products" => [
@@ -207,7 +207,7 @@ class GraphQL::GraphQLTest < Minitest::Test
         product_variants_count(id: "2")
       }
     GRAPHQL
-    result = schema.execute(query_string)
+    result = schema_execute(query_string)
     expected = {
       "data" => {
         "product_variants_count" => 3
@@ -225,7 +225,7 @@ class GraphQL::GraphQLTest < Minitest::Test
         }
       }
     GRAPHQL
-    result = schema.execute(query_string)
+    result = schema_execute(query_string)
     expected = {
       "data" => {
         "product" => {
@@ -253,7 +253,7 @@ class GraphQL::GraphQLTest < Minitest::Test
         }
       }
     GRAPHQL
-    result = schema.execute(query_string)
+    result = schema_execute(query_string)
     expected = {
       "data" => {
         "products" => [
@@ -286,7 +286,7 @@ class GraphQL::GraphQLTest < Minitest::Test
         load_execution_error
       }
     GRAPHQL
-    result = schema.execute(query_string)
+    result = schema_execute(query_string)
     expected = {
       "data" => { "constant"=>"constant value", "load_execution_error" => nil },
       "errors" => [{ "message" => "test error message", "locations"=>[{"line"=>3, "column"=>9}], "path" => ["load_execution_error"] }],
@@ -303,7 +303,7 @@ class GraphQL::GraphQLTest < Minitest::Test
         incr2: increment_counter { value, load_value }
       }
     GRAPHQL
-    result = schema.execute(query_string, context: { counter: [0] })
+    result = schema_execute(query_string, context: { counter: [0] })
     expected = {
       "data" => {
         "count1" => 0,
@@ -328,7 +328,7 @@ class GraphQL::GraphQLTest < Minitest::Test
         }
       }
     GRAPHQL
-    result = schema.execute(query_string)
+    result = schema_execute(query_string)
     expected = {
       "data" => {
         "mutation1" => {


### PR DESCRIPTION
## Problem

I noticed in https://github.com/Shopify/graphql-batch/pull/52 that our tests are now failing with graphql 1.6.0, since it made some breaking changes.

It looks like setting the execution strategy now longer works upstream unless `GraphQL::Query::Executor` is used directly, which is deprecated.

## Solution

Change the tests for this legacy feature to use `GraphQL::Query::Executor` instead of using GraphQL::Schema#execute.  I used a subclass to ignore the warnings for that test.