### PR TITLE
Support GraphQL 1.6's multiplexed execution

### DIFF
--- a/lib/graphql/batch.rb
+++ b/lib/graphql/batch.rb
@@ -10,6 +10,7 @@ module GraphQL
     class NestedError < StandardError; end
 
     def self.batch
+      # TODO: Should this be allowed now?
       raise NestedError if GraphQL::Batch::Executor.current
       begin
         GraphQL::Batch::Executor.current = GraphQL::Batch::Executor.new

--- a/lib/graphql/batch/setup.rb
+++ b/lib/graphql/batch/setup.rb
@@ -1,14 +1,22 @@
 module GraphQL::Batch
   module Setup
     extend self
+    BATCH_COUNT = "#{name}.executor_count"
 
     def before_query(query)
-      raise NestedError if GraphQL::Batch::Executor.current
-      GraphQL::Batch::Executor.current = GraphQL::Batch::Executor.new
+      GraphQL::Batch::Executor.current = GraphQL::Batch::Executor.new if (self.batch_count += 1) == 1
     end
 
     def after_query(query)
-      GraphQL::Batch::Executor.current = nil
+      GraphQL::Batch::Executor.current = nil if (self.batch_count -= 1) == 0
+    end
+
+    def batch_count
+      Thread.current[BATCH_COUNT] || 0
+    end
+
+    def batch_count=(value)
+      Thread.current[BATCH_COUNT] = (value > 0 ? value : nil)
     end
   end
 end

--- a/test/batch_test.rb
+++ b/test/batch_test.rb
@@ -9,6 +9,7 @@ class GraphQL::BatchTest < Minitest::Test
   end
 
   def test_nested_batch
+    # TODO: Update this test?
     GraphQL::Batch.batch do
       assert_raises(GraphQL::Batch::NestedError) do
         GraphQL::Batch.batch {}


### PR DESCRIPTION
In GraphQL 1.6, @rmosolgo introduced the `Schema#multiplex` feature 🎉 which lets you execute multiple queries in one go. But it seems that it invokes the query instrumentation once per query, instead of just once, which causes the `NestedError` to be raised. This change removes the `NestedError` behavior.

I'm opening this PR mainly as a discussion. I'm actually not sure what the ramifications are of allowing this nested behavior. But anywho, thoughts?