### PR TITLE
Prevent loader re-use after mutations

### DIFF
--- a/lib/graphql/batch/loader.rb
+++ b/lib/graphql/batch/loader.rb
@@ -44,8 +44,8 @@ module GraphQL::Batch
     end
 
     def resolve #:nodoc:
+      return if resolved?
       load_keys = queue
-      return if load_keys.empty?
       @queue = nil
       perform(load_keys)
       check_for_broken_promises(load_keys)
@@ -63,6 +63,10 @@ module GraphQL::Batch
       else
         resolve
       end
+    end
+
+    def resolved?
+      @queue.nil? || @queue.empty?
     end
 
     protected

--- a/lib/graphql/batch/loader.rb
+++ b/lib/graphql/batch/loader.rb
@@ -44,8 +44,8 @@ module GraphQL::Batch
     end
 
     def resolve #:nodoc:
-      return if resolved?
       load_keys = queue
+      return if load_keys.empty?
       @queue = nil
       perform(load_keys)
       check_for_broken_promises(load_keys)
@@ -58,14 +58,11 @@ module GraphQL::Batch
     # For Promise#sync
     def wait #:nodoc:
       if executor
+        executor.loaders.delete(loader_key)
         executor.resolve(self)
       else
         resolve
       end
-    end
-
-    def resolved?
-      @queue.nil? || @queue.empty?
     end
 
     protected

--- a/test/graphql_test.rb
+++ b/test/graphql_test.rb
@@ -342,6 +342,6 @@ class GraphQL::GraphQLTest < Minitest::Test
       }
     }
     assert_equal expected, result
-    assert_equal ["Product/1,2", "Product/3"], queries
+    assert_equal ["Product/1,2", "Product/2,3"], queries
   end
 end

--- a/test/support/loaders.rb
+++ b/test/support/loaders.rb
@@ -26,16 +26,12 @@ class AssociationLoader < GraphQL::Batch::Loader
 end
 
 class CounterLoader < GraphQL::Batch::Loader
-  def initialize(hash)
-    @hash = hash
-  end
-
-  def load(key=Object.new)
-    super(key)
+  def cache_key(counter_array)
+    counter_array.object_id
   end
 
   def perform(keys)
-    keys.each { |key| fulfill(key, @hash[:counter][0]) }
+    keys.each { |counter_array| fulfill(counter_array, counter_array[0]) }
   end
 end
 

--- a/test/support/schema.rb
+++ b/test/support/schema.rb
@@ -128,7 +128,7 @@ CounterType = GraphQL::ObjectType.define do
   end
 
   field :load_value, !types.Int do
-    resolve ->(_, _, ctx) { CounterLoader.for(ctx).load }
+    resolve ->(_, _, ctx) { CounterLoader.load(ctx[:counter]) }
   end
 end
 
@@ -136,11 +136,13 @@ MutationType = GraphQL::ObjectType.define do
   name "Mutation"
 
   field :increment_counter, !CounterType do
-    resolve ->(_, _, ctx) { ctx[:counter][0] += 1; CounterLoader.for(ctx).load }
+    resolve ->(_, _, ctx) { ctx[:counter][0] += 1; CounterLoader.load(ctx[:counter]) }
   end
 
   field :counter_loader, !types.Int do
-    resolve ->(_, _, ctx) { CounterLoader.for(ctx).load }
+    resolve ->(_, _, ctx) {
+      CounterLoader.load(ctx[:counter])
+    }
   end
 
   field :no_op, !QueryType do


### PR DESCRIPTION
cc @staugaard

## Problem

The loader re-use added by https://github.com/Shopify/graphql-batch/pull/53 also re-used the loaders and their resolved promises after a mutation field is resolved.

[GraphQL::GraphQLTest#test_mutation_execution](https://github.com/Shopify/graphql-batch/blob/v0.3.3/test/graphql_test.rb#L297) was a test that was supposed to catch this bug, but it was using `CounterLoader.for(ctx).load` where load was defined in CounterLoader with `def load(key=Object.new)`, so it was actually using a unique key for each load which prevented it from ever re-using the result of a previous load.

## Solution

I've reverted https://github.com/Shopify/graphql-batch/pull/53 to fix the bug and updated the test to use override `cache_key` to use the `object_id` of the array that is used to hold the counter.

If the test is run without the revert, then it has the expected failures of

```
  1) Failure:
GraphQL::GraphQLTest#test_mutation_execution [test/graphql_test.rb:315]:
--- expected
+++ actual
@@ -1 +1 @@
-{"data"=>{"count1"=>0, "incr1"=>{"value"=>1, "load_value"=>1}, "count2"=>1, "incr2"=>{"value"=>2, "load_value"=>2}}}
+{"data"=>{"count1"=>0, "incr1"=>{"value"=>0, "load_value"=>0}, "count2"=>0, "incr2"=>{"value"=>0, "load_value"=>0}}}
```