### PR TITLE
feat(GraphQL::Batch::SetupMultiplex) use multiplex instrumentation to share a batching context

### DIFF
--- a/lib/graphql/batch.rb
+++ b/lib/graphql/batch.rb
@@ -20,7 +20,11 @@ module GraphQL
     end
 
     def self.use(schema_defn)
-      schema_defn.instrument(:query, GraphQL::Batch::Setup)
+      if GraphQL::VERSION >= "1.6.0"
+        schema_defn.instrument(:multiplex, GraphQL::Batch::SetupMultiplex)
+      else
+        schema_defn.instrument(:query, GraphQL::Batch::Setup)
+      end
       schema_defn.lazy_resolve(::Promise, :sync)
     end
 
@@ -34,3 +38,4 @@ require_relative "batch/loader"
 require_relative "batch/executor"
 require_relative "batch/promise"
 require_relative "batch/setup"
+require_relative "batch/setup_multiplex"

--- a/lib/graphql/batch/setup_multiplex.rb
+++ b/lib/graphql/batch/setup_multiplex.rb
@@ -1,0 +1,14 @@
+module GraphQL::Batch
+  module SetupMultiplex
+    extend self
+
+    def before_multiplex(multiplex)
+      raise NestedError if GraphQL::Batch::Executor.current
+      GraphQL::Batch::Executor.current = GraphQL::Batch::Executor.new
+    end
+
+    def after_multiplex(multiplex)
+      GraphQL::Batch::Executor.current = nil
+    end
+  end
+end

--- a/test/multiplex_test.rb
+++ b/test/multiplex_test.rb
@@ -1,0 +1,51 @@
+require_relative 'test_helper'
+
+class GraphQL::MultiplexTest < Minitest::Test
+  attr_reader :queries
+
+  def setup
+    @queries = []
+    QueryNotifier.subscriber = ->(query) { @queries << query }
+  end
+
+  def teardown
+    QueryNotifier.subscriber = nil
+  end
+
+  def schema_multiplex(*args)
+    ::Schema.multiplex(*args)
+  end
+
+
+  def test_batched_find_by_id
+    query_string = <<-GRAPHQL
+      query FetchTwoProducts($id1: ID!, $id2: ID!){
+        first: product(id: $id1) { id, title }
+        second: product(id: $id2) { id, title }
+      }
+    GRAPHQL
+
+    results = schema_multiplex([
+      { query: query_string, variables: { "id1" => "1", "id2" => "2"} },
+      { query: query_string, variables: { "id1" => "1", "id2" => "3"}},
+    ])
+
+    expected_1 = {
+      "data" => {
+        "first" => { "id" => "1", "title" => "Shirt" },
+        "second" => { "id" => "2", "title" => "Pants" },
+      }
+    }
+
+    expected_2 = {
+      "data" => {
+        "first" => { "id" => "1", "title" => "Shirt" },
+        "second" => { "id" => "3", "title" => "Sweater" },
+      }
+    }
+
+    assert_equal expected_1, results.first
+    assert_equal expected_2, results.last
+    assert_equal ["Product/1,2,3"], queries
+  end
+end

--- a/test/multiplex_test.rb
+++ b/test/multiplex_test.rb
@@ -12,11 +12,6 @@ class GraphQL::MultiplexTest < Minitest::Test
     QueryNotifier.subscriber = nil
   end
 
-  def schema_multiplex(*args)
-    ::Schema.multiplex(*args)
-  end
-
-
   def test_batched_find_by_id
     query_string = <<-GRAPHQL
       query FetchTwoProducts($id1: ID!, $id2: ID!){
@@ -25,7 +20,7 @@ class GraphQL::MultiplexTest < Minitest::Test
       }
     GRAPHQL
 
-    results = schema_multiplex([
+    results = Schema.multiplex([
       { query: query_string, variables: { "id1" => "1", "id2" => "2"} },
       { query: query_string, variables: { "id1" => "1", "id2" => "3"}},
     ])


### PR DESCRIPTION
This patch adds support for a shared batching context when multiple queries are run concurrently. Is it something you're interested in for this gem?

Single queries are still supported because graphql 1.6+ treats `Schema#execute` as a special case of `Schema#multiplex`: a multiplex with one query. So it's still covered by `instrument(:multiplex,...)`. 