### PR TITLE
Deprecated ExecutionStrategy has better query performance

### DIFF
--- a/test/support/schema.rb
+++ b/test/support/schema.rb
@@ -62,6 +62,15 @@ ProductType = GraphQL::ObjectType.define do
       Promise.all([query]).then { query.value.size }
     }
   end
+
+  field :this_product do
+    type -> { ProductType }
+    resolve -> (product, args, ctx) {
+      Promise.all([]).then do
+        product
+      end
+    }
+  end
 end
 
 QueryType = GraphQL::ObjectType.define do


### PR DESCRIPTION
Hi! This PR isn't really meant to be merged, just to demonstrate an issue I ran into. It's probably more of an issue with GraphQL than with GraphQL::Batch, but I figured I'd start by opening it here for discussion.

I'm not 100% sure what's going on, but the deprecated GraphQL::Batch::ExecutionStrategy class seems to do a better job of aggregating queries than the non-deprecated integration. Specifically, the test case in this PR passes with `LegacySchema` but fails with `Schema`:

      1) Failure:
    GraphQL::GraphQLTest#test_deeply_nested_lazy_queries [/Users/rfitz/src/vendor/graphql-batch/test/graphql_test.rb:320]:
    --- expected
    +++ actual
    @@ -1 +1 @@
    -["Product?limit=2", "Product/1,2/variants", "ProductVariant/1,2,4,5,6/images"]
    +["Product?limit=2", "Product/1,2/variants", "ProductVariant/1,2/images", "ProductVariant/4,5,6/images"]

The difference between this test and the existing `test_load_list_of_objects_with_loaded_field` is just an extra layer of laziness in the query.

I'm happy to just use ExecutionStrategy for now, but what's the path forward here? Should I open an issue on the GraphQL gem, or is this something that can be addressed at the GraphQL::Batch layer?