### PR TITLE
Re-use loaders after they have been performed, but clear on mutation

### DIFF
--- a/lib/graphql/batch.rb
+++ b/lib/graphql/batch.rb
@@ -20,10 +20,15 @@ module GraphQL
     end
 
     def self.use(schema_defn)
+      schema = schema_defn.target
       if GraphQL::VERSION >= "1.6.0"
-        schema_defn.instrument(:multiplex, GraphQL::Batch::SetupMultiplex)
+        instrumentation = GraphQL::Batch::SetupMultiplex.new(schema)
+        schema_defn.instrument(:multiplex, instrumentation)
+        schema_defn.instrument(:field, instrumentation)
       else
-        schema_defn.instrument(:query, GraphQL::Batch::Setup)
+        instrumentation = GraphQL::Batch::Setup.new(schema)
+        schema_defn.instrument(:query, instrumentation)
+        schema_defn.instrument(:field, instrumentation)
       end
       schema_defn.lazy_resolve(::Promise, :sync)
     end

--- a/lib/graphql/batch/loader.rb
+++ b/lib/graphql/batch/loader.rb
@@ -58,7 +58,6 @@ module GraphQL::Batch
     # For Promise#sync
     def wait #:nodoc:
       if executor
-        executor.loaders.delete(loader_key)
         executor.resolve(self)
       else
         resolve

--- a/lib/graphql/batch/mutation_execution_strategy.rb
+++ b/lib/graphql/batch/mutation_execution_strategy.rb
@@ -9,11 +9,13 @@ module GraphQL::Batch
         strategy = execution_context.strategy
         return super if strategy.enable_batching
 
+        GraphQL::Batch::Executor.current.clear
         begin
           strategy.enable_batching = true
           strategy.deep_sync(Promise.sync(super))
         ensure
           strategy.enable_batching = false
+          GraphQL::Batch::Executor.current.clear
         end
       end
     end

--- a/lib/graphql/batch/setup.rb
+++ b/lib/graphql/batch/setup.rb
@@ -1,14 +1,54 @@
 module GraphQL::Batch
-  module Setup
-    extend self
+  class Setup
+    class << self
+      def start_batching
+        raise NestedError if GraphQL::Batch::Executor.current
+        GraphQL::Batch::Executor.current = GraphQL::Batch::Executor.new
+      end
+
+      def end_batching
+        GraphQL::Batch::Executor.current = nil
+      end
+
+      def instrument_field(schema, type, field)
+        return field unless type == schema.mutation
+        old_resolve_proc = field.resolve_proc
+        field.redefine do
+          resolve ->(obj, args, ctx) {
+            GraphQL::Batch::Executor.current.clear
+            begin
+              Promise.sync(old_resolve_proc.call(obj, args, ctx))
+            ensure
+              GraphQL::Batch::Executor.current.clear
+            end
+          }
+        end
+      end
+
+      def before_query(query)
+        warn "Deprecated graphql-batch setup `instrument(:query, GraphQL::Batch::Setup)`, replace with `use GraphQL::Batch`"
+        start_batching
+      end
+
+      def after_query(query)
+        end_batching
+      end
+    end
+
+    def initialize(schema)
+      @schema = schema
+    end
 
     def before_query(query)
-      raise NestedError if GraphQL::Batch::Executor.current
-      GraphQL::Batch::Executor.current = GraphQL::Batch::Executor.new
+      Setup.start_batching
     end
 
     def after_query(query)
-      GraphQL::Batch::Executor.current = nil
+      Setup.end_batching
+    end
+
+    def instrument(type, field)
+      Setup.instrument_field(@schema, type, field)
     end
   end
 end

--- a/lib/graphql/batch/setup_multiplex.rb
+++ b/lib/graphql/batch/setup_multiplex.rb
@@ -1,14 +1,19 @@
 module GraphQL::Batch
-  module SetupMultiplex
-    extend self
+  class SetupMultiplex
+    def initialize(schema)
+      @schema = schema
+    end
 
     def before_multiplex(multiplex)
-      raise NestedError if GraphQL::Batch::Executor.current
-      GraphQL::Batch::Executor.current = GraphQL::Batch::Executor.new
+      Setup.start_batching
     end
 
     def after_multiplex(multiplex)
-      GraphQL::Batch::Executor.current = nil
+      Setup.end_batching
+    end
+
+    def instrument(type, field)
+      Setup.instrument_field(@schema, type, field)
     end
   end
 end

--- a/test/graphql_test.rb
+++ b/test/graphql_test.rb
@@ -279,6 +279,36 @@ class GraphQL::GraphQLTest < Minitest::Test
     assert_equal ["Product?limit=2", "Product/1,2/variants", "ProductVariant/1,2,4,5,6/images"], queries
   end
 
+  def test_loader_reused_after_loading
+    query_string = <<-GRAPHQL
+      {
+        product(id: "2") {
+          variants {
+            id
+            product {
+              id
+              title
+            }
+          }
+        }
+      }
+    GRAPHQL
+    result = schema_execute(query_string)
+    expected = {
+      "data" => {
+        "product" => {
+          "variants" => [
+            { "id" => "4", "product" => { "id" => "2", "title" => "Pants" } },
+            { "id" => "5", "product" => { "id" => "2", "title" => "Pants" } },
+            { "id" => "6", "product" => { "id" => "2", "title" => "Pants" } },
+          ],
+        }
+      }
+    }
+    assert_equal expected, result
+    assert_equal ["Product/2", "Product/2/variants"], queries
+  end
+
   def test_load_error
     query_string = <<-GRAPHQL
       {

--- a/test/support/schema.rb
+++ b/test/support/schema.rb
@@ -17,6 +17,11 @@ ProductVariantType = GraphQL::ObjectType.define do
       end
     }
   end
+  field :product, !ProductType do
+    resolve ->(variant, _, _) {
+      RecordLoader.for(Product).load(variant.product_id)
+    }
+  end
 end
 
 ProductType = GraphQL::ObjectType.define do


### PR DESCRIPTION
Fixes #43

## Problem

https://github.com/Shopify/graphql-batch/pull/56 reverted a change that re-uses loaders after they are loaded so that they aren't re-used after a mutation.

## Solution

Add field instrumentation to wrap the resolve proc for mutation fields in order to clear the loaders cache before and after it is called.

Identifying which fields were mutation fields required having the schema in the instrumentation, so I changed the setup modules into classes that take the schema as an initializer.  Before #51 we recommended using `instrument(:query, GraphQL::Batch::Setup)` in the README, so I have added class methods to deprecate that old usage.