### PR TITLE
Return a normal Promise object from GraphQL::Batch::Loader#load

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,5 @@ language: ruby
 rvm:
   - 2.1
   - 2.2
+  - 2.3
 before_install: gem install bundler -v 1.13.3

--- a/lib/graphql/batch.rb
+++ b/lib/graphql/batch.rb
@@ -13,7 +13,7 @@ module GraphQL
       raise NestedError if GraphQL::Batch::Executor.current
       begin
         GraphQL::Batch::Executor.current = GraphQL::Batch::Executor.new
-        Promise.sync(yield)
+        ::Promise.sync(yield)
       ensure
         GraphQL::Batch::Executor.current = nil
       end

--- a/lib/graphql/batch/execution_strategy.rb
+++ b/lib/graphql/batch/execution_strategy.rb
@@ -13,7 +13,7 @@ module GraphQL::Batch
 
     # Needed for MutationExecutionStrategy
     def deep_sync(result) #:nodoc:
-      Promise.sync(as_promise_unless_resolved(result))
+      ::Promise.sync(as_promise_unless_resolved(result))
     end
 
     private

--- a/lib/graphql/batch/loader.rb
+++ b/lib/graphql/batch/loader.rb
@@ -12,10 +12,7 @@ module GraphQL::Batch
           " `GraphQL::Batch::Setup` as a query instrumenter if using with `graphql-ruby`"
       end
 
-      executor.loaders[loader_key] ||= new(*group_args).tap do |loader|
-        loader.loader_key = loader_key
-        loader.executor = executor
-      end
+      executor.loader(loader_key) { new(*group_args) }
     end
 
     def self.loader_key_for(*group_args)

--- a/lib/graphql/batch/loader.rb
+++ b/lib/graphql/batch/loader.rb
@@ -32,7 +32,7 @@ module GraphQL::Batch
     def load(key)
       cache[cache_key(key)] ||= begin
         queue << key
-        Promise.new.tap { |promise| promise.source = self }
+        ::Promise.new.tap { |promise| promise.source = self }
       end
     end
 
@@ -47,9 +47,7 @@ module GraphQL::Batch
       perform(load_keys)
       check_for_broken_promises(load_keys)
     rescue => err
-      each_pending_promise(load_keys) do |key, promise|
-        promise.reject(err)
-      end
+      reject_pending_promises
     end
 
     # For Promise#sync
@@ -69,7 +67,15 @@ module GraphQL::Batch
 
     # Fulfill the key with provided value, for use in #perform
     def fulfill(key, value)
-      promise_for(key).fulfill(value)
+      finish_resolve(key) do |promise|
+        promise.fulfill(value)
+      end
+    end
+
+    def reject(key, reason)
+      finish_resolve(key) do |promise|
+        promise.reject(reason)
+      end
     end
 
     # Returns true when the key has already been fulfilled, otherwise returns false
@@ -89,6 +95,14 @@ module GraphQL::Batch
 
     private
 
+    def finish_resolve(key)
+      promise = promise_for(key)
+      return yield(promise) unless executor
+      executor.around_promise_callbacks do
+        yield promise
+      end
+    end
+
     def cache
       @cache ||= {}
     end
@@ -101,18 +115,16 @@ module GraphQL::Batch
       cache.fetch(cache_key(load_key))
     end
 
-    def each_pending_promise(load_keys)
+    def reject_pending_promises
       load_keys.each do |key|
-        promise = promise_for(key)
-        if promise.pending?
-          yield key, promise
-        end
+        # promise.rb ignores reject if promise isn't pending
+        reject(key, err)
       end
     end
 
     def check_for_broken_promises(load_keys)
-      each_pending_promise(load_keys) do |key, promise|
-        promise.reject(::Promise::BrokenError.new("#{self.class} didn't fulfill promise for key #{key.inspect}"))
+      load_keys.each do |key|
+        reject(key, ::Promise::BrokenError.new("#{self.class} didn't fulfill promise for key #{key.inspect}"))
       end
     end
   end

--- a/lib/graphql/batch/mutation_execution_strategy.rb
+++ b/lib/graphql/batch/mutation_execution_strategy.rb
@@ -12,7 +12,7 @@ module GraphQL::Batch
         GraphQL::Batch::Executor.current.clear
         begin
           strategy.enable_batching = true
-          strategy.deep_sync(Promise.sync(super))
+          strategy.deep_sync(::Promise.sync(super))
         ensure
           strategy.enable_batching = false
           GraphQL::Batch::Executor.current.clear

--- a/lib/graphql/batch/promise.rb
+++ b/lib/graphql/batch/promise.rb
@@ -1,8 +1,6 @@
 module GraphQL::Batch
-  class Promise < ::Promise
-    def defer
-      executor = Executor.current
-      executor ? executor.defer { super } : super
-    end
+  Promise = ::Promise
+  if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.3")
+    deprecate_constant :Promise
   end
 end

--- a/lib/graphql/batch/setup.rb
+++ b/lib/graphql/batch/setup.rb
@@ -17,7 +17,7 @@ module GraphQL::Batch
           resolve ->(obj, args, ctx) {
             GraphQL::Batch::Executor.current.clear
             begin
-              Promise.sync(old_resolve_proc.call(obj, args, ctx))
+              ::Promise.sync(old_resolve_proc.call(obj, args, ctx))
             ensure
               GraphQL::Batch::Executor.current.clear
             end


### PR DESCRIPTION
Fixes #60 (cc @jpserra)

@arthurschreiber would this remove the need for https://github.com/lgierth/promise.rb/pull/35 ?

As I mentioned in #60 

> The reason for the difference is more of an implementation detail. The only difference between ::Promise and GraphQL::Batch::Promise is that GraphQL::Batch::Promise overrides defer so that we can use GraphQL::Batch::Executor.current.loading in tests to detect when an unbatched query is performed in a test.

so I refactored the code so that GraphQL::Batch::Loader's fulfill and reject methods call `executor.around_promise_callbacks do` around the actually fulfillment or rejection of the promise, allowing the executor to set its loading flag to `false` before promise callbacks are called and reset back to `true` for the remainder of the loaders perform method.