### PR TITLE
Allow custom executors

### DIFF
--- a/lib/graphql/batch.rb
+++ b/lib/graphql/batch.rb
@@ -19,14 +19,14 @@ module GraphQL
       end
     end
 
-    def self.use(schema_defn)
+    def self.use(schema_defn, executor_class: GraphQL::Batch::Executor)
       schema = schema_defn.target
       if GraphQL::VERSION >= "1.6.0"
-        instrumentation = GraphQL::Batch::SetupMultiplex.new(schema)
+        instrumentation = GraphQL::Batch::SetupMultiplex.new(schema, executor_class: executor_class)
         schema_defn.instrument(:multiplex, instrumentation)
         schema_defn.instrument(:field, instrumentation)
       else
-        instrumentation = GraphQL::Batch::Setup.new(schema)
+        instrumentation = GraphQL::Batch::Setup.new(schema, executor_class: executor_class)
         schema_defn.instrument(:query, instrumentation)
         schema_defn.instrument(:field, instrumentation)
       end

--- a/lib/graphql/batch/setup.rb
+++ b/lib/graphql/batch/setup.rb
@@ -1,9 +1,9 @@
 module GraphQL::Batch
   class Setup
     class << self
-      def start_batching
+      def start_batching(executor_class)
         raise NestedError if GraphQL::Batch::Executor.current
-        GraphQL::Batch::Executor.current = GraphQL::Batch::Executor.new
+        GraphQL::Batch::Executor.current = executor_class.new
       end
 
       def end_batching
@@ -27,7 +27,7 @@ module GraphQL::Batch
 
       def before_query(query)
         warn "Deprecated graphql-batch setup `instrument(:query, GraphQL::Batch::Setup)`, replace with `use GraphQL::Batch`"
-        start_batching
+        start_batching(GraphQL::Batch::Executor)
       end
 
       def after_query(query)
@@ -35,12 +35,13 @@ module GraphQL::Batch
       end
     end
 
-    def initialize(schema)
+    def initialize(schema, executor_class:)
       @schema = schema
+      @executor_class = executor_class
     end
 
     def before_query(query)
-      Setup.start_batching
+      Setup.start_batching(@executor_class)
     end
 
     def after_query(query)

--- a/lib/graphql/batch/setup_multiplex.rb
+++ b/lib/graphql/batch/setup_multiplex.rb
@@ -1,11 +1,12 @@
 module GraphQL::Batch
   class SetupMultiplex
-    def initialize(schema)
+    def initialize(schema, executor_class:)
       @schema = schema
+      @executor_class = executor_class
     end
 
     def before_multiplex(multiplex)
-      Setup.start_batching
+      Setup.start_batching(@executor_class)
     end
 
     def after_multiplex(multiplex)

--- a/test/custom_executor_test.rb
+++ b/test/custom_executor_test.rb
@@ -1,0 +1,31 @@
+require_relative 'test_helper'
+
+class GraphQL::Batch::CustomExecutorTest < Minitest::Test
+  class MyCustomExecutor < GraphQL::Batch::Executor
+    @@call_count = 0
+
+    def self.call_count
+      @@call_count
+    end
+
+    def around_promise_callbacks
+      @@call_count += 1
+
+      super
+    end
+  end
+
+  def test_custom_executor_class
+    schema = GraphQL::Schema.define do
+      query ::QueryType
+      mutation ::MutationType
+
+      use GraphQL::Batch, executor_class: MyCustomExecutor
+    end
+
+    query_string = '{ product(id: "1") { id } }'
+    schema.execute(query_string)
+
+    assert MyCustomExecutor.call_count > 0
+  end
+end


### PR DESCRIPTION
* Changed: GraphQL::Batch.use can take optional `custom_executor`
  * `GraphQL::Batch::Setup` and `GraphQL::Batch::SetupMultiplex` updated to hold reference to the executor class (defaults to GraphQL::Batch::Executor) as instance variables.

@dylanahsmith @eapache @swalkinshaw 👋 ~~I'm looking to verify my approach here before continuing. See the linked Shopify/shopify PR for more context.~~ Updated according PR review comments so far.