### PR TITLE
Fix reject_pending_promises handling

### DIFF
--- a/lib/graphql/batch/loader.rb
+++ b/lib/graphql/batch/loader.rb
@@ -47,7 +47,7 @@ module GraphQL::Batch
       perform(load_keys)
       check_for_broken_promises(load_keys)
     rescue => err
-      reject_pending_promises
+      reject_pending_promises(load_keys, err)
     end
 
     # For Promise#sync
@@ -115,7 +115,7 @@ module GraphQL::Batch
       cache.fetch(cache_key(load_key))
     end
 
-    def reject_pending_promises
+    def reject_pending_promises(load_keys, err)
       load_keys.each do |key|
         # promise.rb ignores reject if promise isn't pending
         reject(key, err)

--- a/test/loader_test.rb
+++ b/test/loader_test.rb
@@ -33,6 +33,12 @@ class GraphQL::Batch::LoaderTest < Minitest::Test
     end
   end
 
+  class ExplodingLoader < GraphQL::Batch::Loader
+    def perform(_keys)
+      raise 'perform failed'
+    end
+  end
+
   def setup
     GraphQL::Batch::Executor.current = GraphQL::Batch::Executor.new
   end
@@ -161,5 +167,11 @@ class GraphQL::Batch::LoaderTest < Minitest::Test
       loader2.load(:b),
     ])
     assert_equal [2, 1, 2], group.sync
+  end
+
+  def test_loader_with_failing_perform
+    error_message = nil
+    promise = ExplodingLoader.load([1]).then(nil, ->(err) { error_message = err.message } ).sync
+    assert_equal 'perform failed', error_message
   end
 end


### PR DESCRIPTION
A test within Shopify that sets an expectation on Loader#perform to raise an error exposed a problem with our implementation of `Loader#reject_pending_promises`:
```
NameError: undefined local variable or method `load_keys' for #
graphql-batch/lib/graphql/batch/loader.rb:120:in `reject_pending_promises'
```

The method was not previously covered in tests, and the NameError it raises obscures other exceptions raised within `perform`. This PR fixes this.