### PR TITLE
Allow nested queries.

### DIFF
--- a/lib/graphql/batch.rb
+++ b/lib/graphql/batch.rb
@@ -7,15 +7,13 @@ require "promise.rb"
 module GraphQL
   module Batch
     BrokenPromiseError = ::Promise::BrokenError
-    class NestedError < StandardError; end
 
     def self.batch
-      raise NestedError if GraphQL::Batch::Executor.current
       begin
-        GraphQL::Batch::Executor.current = GraphQL::Batch::Executor.new
+        GraphQL::Batch::Executor.start_batch GraphQL::Batch::Executor
         ::Promise.sync(yield)
       ensure
-        GraphQL::Batch::Executor.current = nil
+        GraphQL::Batch::Executor.end_batch
       end
     end
 

--- a/lib/graphql/batch/setup.rb
+++ b/lib/graphql/batch/setup.rb
@@ -2,12 +2,11 @@ module GraphQL::Batch
   class Setup
     class << self
       def start_batching(executor_class)
-        raise NestedError if GraphQL::Batch::Executor.current
-        GraphQL::Batch::Executor.current = executor_class.new
+        GraphQL::Batch::Executor.start_batch(executor_class)
       end
 
       def end_batching
-        GraphQL::Batch::Executor.current = nil
+        GraphQL::Batch::Executor.end_batch
       end
 
       def instrument_field(schema, type, field)

--- a/test/batch_test.rb
+++ b/test/batch_test.rb
@@ -9,10 +9,19 @@ class GraphQL::BatchTest < Minitest::Test
   end
 
   def test_nested_batch
-    GraphQL::Batch.batch do
-      assert_raises(GraphQL::Batch::NestedError) do
-        GraphQL::Batch.batch {}
+    promise1 = nil
+    promise2 = nil
+
+    product = GraphQL::Batch.batch do
+      promise1 = RecordLoader.for(Product).load(1)
+      GraphQL::Batch.batch do
+        promise2 = RecordLoader.for(Product).load(1)
       end
+      promise1
     end
+
+    assert_equal 'Shirt', product.title
+    assert_equal promise1, promise2
+    assert_nil GraphQL::Batch::Executor.current
   end
 end


### PR DESCRIPTION
This PR removes `GraphQL::Batch:: NestedError` and the associated restriction on nested queries. See https://github.com/Shopify/graphql-batch/issues/70 for details.