### PR TITLE
Fix NoExecutorError

### DIFF
--- a/lib/graphql/batch.rb
+++ b/lib/graphql/batch.rb
@@ -3,12 +3,11 @@ if Gem::Version.new(GraphQL::VERSION) < Gem::Version.new("1.3")
   warn "graphql gem versions less than 1.3 are deprecated for use with graphql-batch, upgrade so lazy_resolve can be used"
 end
 require "promise.rb"
-require_relative "batch/loader"
 
 module GraphQL
   module Batch
     BrokenPromiseError = ::Promise::BrokenError
-    NoExecutorError = Loader::NoExecutorError
+    class NoExecutorError < StandardError; end
 
     def self.batch
       begin
@@ -39,6 +38,7 @@ module GraphQL
 end
 
 require_relative "batch/version"
+require_relative "batch/loader"
 require_relative "batch/executor"
 require_relative "batch/promise"
 require_relative "batch/setup"

--- a/lib/graphql/batch.rb
+++ b/lib/graphql/batch.rb
@@ -3,11 +3,12 @@ if Gem::Version.new(GraphQL::VERSION) < Gem::Version.new("1.3")
   warn "graphql gem versions less than 1.3 are deprecated for use with graphql-batch, upgrade so lazy_resolve can be used"
 end
 require "promise.rb"
+require_relative "batch/loader"
 
 module GraphQL
   module Batch
     BrokenPromiseError = ::Promise::BrokenError
-    class NoExecutorError < StandardError; end
+    NoExecutorError = Loader::NoExecutorError
 
     def self.batch
       begin
@@ -38,7 +39,6 @@ module GraphQL
 end
 
 require_relative "batch/version"
-require_relative "batch/loader"
 require_relative "batch/executor"
 require_relative "batch/promise"
 require_relative "batch/setup"

--- a/lib/graphql/batch.rb
+++ b/lib/graphql/batch.rb
@@ -7,6 +7,7 @@ require "promise.rb"
 module GraphQL
   module Batch
     BrokenPromiseError = ::Promise::BrokenError
+    class NoExecutorError < StandardError; end
 
     def self.batch
       begin

--- a/lib/graphql/batch/executor.rb
+++ b/lib/graphql/batch/executor.rb
@@ -20,8 +20,7 @@ module GraphQL::Batch
       def end_batch
         executor = current
         unless executor
-          raise GraphQL::Batch::NoExecutorError,
-                'Cannot end a batch without an Executor.'
+          raise NoExecutorError, 'Cannot end a batch without an Executor.'
         end
         return unless executor.decrement_level < 1
         self.current = nil

--- a/lib/graphql/batch/executor.rb
+++ b/lib/graphql/batch/executor.rb
@@ -20,7 +20,8 @@ module GraphQL::Batch
       def end_batch
         executor = current
         unless executor
-          raise GraphQL::Batch::NoExecutorError, 'Cannot end a batch without an Executor.'
+          raise GraphQL::Batch::NoExecutorError,
+                'Cannot end a batch without an Executor.'
         end
         return unless executor.decrement_level < 1
         self.current = nil

--- a/lib/graphql/batch/executor.rb
+++ b/lib/graphql/batch/executor.rb
@@ -20,7 +20,7 @@ module GraphQL::Batch
       def end_batch
         executor = current
         unless executor
-          raise NoExecutorError, 'Cannot end a batch without an Executor.'
+          raise GraphQL::Batch::NoExecutorError, 'Cannot end a batch without an Executor.'
         end
         return unless executor.decrement_level < 1
         self.current = nil

--- a/lib/graphql/batch/loader.rb
+++ b/lib/graphql/batch/loader.rb
@@ -7,7 +7,7 @@ module GraphQL::Batch
       executor = Executor.current
 
       unless executor
-        raise NoExecutorError, "Cannot create loader without an Executor."\
+        raise GraphQL::Batch::NoExecutorError, "Cannot create loader without an Executor."\
           " Wrap the call to `for` with `GraphQL::Batch.batch` or use"\
           " `GraphQL::Batch::Setup` as a query instrumenter if using with `graphql-ruby`"
       end

--- a/lib/graphql/batch/loader.rb
+++ b/lib/graphql/batch/loader.rb
@@ -1,6 +1,6 @@
 module GraphQL::Batch
   class Loader
-    class NoExecutorError < StandardError; end
+    NoExecutorError = GraphQL::Batch::NoExecutorError
     deprecate_constant :NoExecutorError
 
     def self.for(*group_args)

--- a/lib/graphql/batch/loader.rb
+++ b/lib/graphql/batch/loader.rb
@@ -1,7 +1,7 @@
 module GraphQL::Batch
   class Loader
     NoExecutorError = GraphQL::Batch::NoExecutorError
-    deprecate_constant :NoExecutorError
+    deprecate_constant :NoExecutorError if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.3")
 
     def self.for(*group_args)
       loader_key = loader_key_for(*group_args)

--- a/lib/graphql/batch/loader.rb
+++ b/lib/graphql/batch/loader.rb
@@ -1,6 +1,7 @@
 module GraphQL::Batch
   class Loader
     class NoExecutorError < StandardError; end
+    deprecate_constant :NoExecutorError
 
     def self.for(*group_args)
       loader_key = loader_key_for(*group_args)

--- a/lib/graphql/batch/loader.rb
+++ b/lib/graphql/batch/loader.rb
@@ -7,9 +7,10 @@ module GraphQL::Batch
       executor = Executor.current
 
       unless executor
-        raise GraphQL::Batch::NoExecutorError, "Cannot create loader without an Executor."\
-          " Wrap the call to `for` with `GraphQL::Batch.batch` or use"\
-          " `GraphQL::Batch::Setup` as a query instrumenter if using with `graphql-ruby`"
+        raise GraphQL::Batch::NoExecutorError, 'Cannot create loader without'\
+          ' an Executor. Wrap the call to `for` with `GraphQL::Batch.batch`'\
+          ' or use `GraphQL::Batch::Setup` as a query instrumenter if'\
+          ' using with `graphql-ruby`'
       end
 
       executor.loader(loader_key) { new(*group_args) }

--- a/test/executor_test.rb
+++ b/test/executor_test.rb
@@ -46,4 +46,12 @@ class GraphQL::Batch::ExecutorTest < Minitest::Test
     end.sync
     assert_equal true, loader2.loading_in_perform
   end
+
+  def test_end_batch_with_no_executor
+    GraphQL::Batch::Executor.current = nil
+
+    assert_raises(GraphQL::Batch::NoExecutorError) do
+      GraphQL::Batch::Executor.end_batch
+    end
+  end
 end

--- a/test/loader_test.rb
+++ b/test/loader_test.rb
@@ -50,7 +50,7 @@ class GraphQL::Batch::LoaderTest < Minitest::Test
   def test_no_executor
     GraphQL::Batch::Executor.current = nil
 
-    assert_raises(GraphQL::Batch::Loader::NoExecutorError) do
+    assert_raises(GraphQL::Batch::NoExecutorError) do
       EchoLoader.for
     end
   end


### PR DESCRIPTION
When ending a batch with no executor, we would try to raise a `NoExecutorError` in `Executor` but a name error would occur because that class is defined in `Loader`.

In this PR I'm moving this error to `GraphQL::Batch` instead since it may happen both in `Loader` and `Executor`.

Also added a test to ensure this code path is tested.