### PR TITLE
Do not try to reject pending promises.

### DIFF
--- a/lib/graphql/batch/loader.rb
+++ b/lib/graphql/batch/loader.rb
@@ -119,13 +119,16 @@ module GraphQL::Batch
 
     def reject_pending_promises(load_keys, err)
       load_keys.each do |key|
-        # promise.rb ignores reject if promise isn't pending
+        next unless promise_for(key).pending?
+
         reject(key, err)
       end
     end
 
     def check_for_broken_promises(load_keys)
       load_keys.each do |key|
+        next unless promise_for(key).pending?
+
         reject(key, ::Promise::BrokenError.new("#{self.class} didn't fulfill promise for key #{key.inspect}"))
       end
     end


### PR DESCRIPTION
This fixes an issue where `Loader#check_for_broken_promises` was generating a large amount of unused `Promise::BrokenError` objects and strings in case there were no broken promises after the loader finished execution.

By skipping the error object creation for promises that are no longer pending, we can also skip generating these objects.