### PR TITLE
Shouldn't reject if the promise is fulfilled

### DIFF
--- a/lib/graphql/batch/loader.rb
+++ b/lib/graphql/batch/loader.rb
@@ -127,7 +127,7 @@ module GraphQL::Batch
 
     def check_for_broken_promises(load_keys)
       load_keys.each do |key|
-        next unless promise_for(key).pending?
+        next unless promise_for(key).pending? || promise_for(key).fulfilled?
 
         reject(key, ::Promise::BrokenError.new("#{self.class} didn't fulfill promise for key #{key.inspect}"))
       end


### PR DESCRIPTION
From my understanding, the purpose of `check_for_broken_promises` is to reject and notify of any promises not fulfilled, however, it only checks if the promise is still pending. It currently rejects if the promise has been fulfilled. Based on the error message, I believe this is incorrect.