### PR TITLE
test: Remove no longer needed schema_execute helper method

### DIFF
--- a/test/graphql_test.rb
+++ b/test/graphql_test.rb
@@ -12,13 +12,9 @@ class GraphQL::GraphQLTest < Minitest::Test
     QueryNotifier.subscriber = nil
   end
 
-  def schema_execute(query_string, **kwargs)
-    ::Schema.execute(query_string, **kwargs)
-  end
-
   def test_no_queries
     query_string = '{ constant }'
-    result = schema_execute(query_string)
+    result = Schema.execute(query_string)
     expected = {
       "data" => {
         "constant" => "constant value"
@@ -37,7 +33,7 @@ class GraphQL::GraphQLTest < Minitest::Test
         }
       }
     GRAPHQL
-    result = schema_execute(query_string)
+    result = Schema.execute(query_string)
     expected = {
       "data" => {
         "product" => {
@@ -57,7 +53,7 @@ class GraphQL::GraphQLTest < Minitest::Test
         product2: product(id: "2") { id, title }
       }
     GRAPHQL
-    result = schema_execute(query_string)
+    result = Schema.execute(query_string)
     expected = {
       "data" => {
         "product1" => { "id" => "1", "title" => "Shirt" },
@@ -77,7 +73,7 @@ class GraphQL::GraphQLTest < Minitest::Test
         }
       }
     GRAPHQL
-    result = schema_execute(query_string)
+    result = Schema.execute(query_string)
     expected = { "data" => { "product" => nil } }
     assert_equal expected, result
     assert_equal ["Product/123"], queries
@@ -92,7 +88,7 @@ class GraphQL::GraphQLTest < Minitest::Test
         }
       }
     GRAPHQL
-    result = schema_execute(query_string)
+    result = Schema.execute(query_string)
     expected = { 'data' => { 'product' => nil }, 'errors' => [{ 'message' => 'Error', 'locations' => [{ 'line' => 4, 'column' => 11 }], 'path' => ['product', 'nonNullButRaises'] }] }
     assert_equal expected, result
   end
@@ -105,13 +101,13 @@ class GraphQL::GraphQLTest < Minitest::Test
         }
       }
     GRAPHQL
-    result = schema_execute(query_string)
+    result = Schema.execute(query_string)
     expected = { 'data' => nil, 'errors' => [{ 'message' => 'Error', 'locations' => [{ 'line' => 2, 'column' => 9 }], 'path' => ['nonNullButRaises'] }] }
     assert_equal expected, result
   end
 
   def test_non_null_field_promise_raises
-    result = schema_execute('{ nonNullButPromiseRaises }')
+    result = Schema.execute('{ nonNullButPromiseRaises }')
     expected = { 'data' => nil, 'errors' => [{ 'message' => 'Error', 'locations' => [{ 'line' => 1, 'column' => 3 }], 'path' => ['nonNullButPromiseRaises'] }] }
     assert_equal expected, result
   end
@@ -129,7 +125,7 @@ class GraphQL::GraphQLTest < Minitest::Test
         }
       }
     GRAPHQL
-    result = schema_execute(query_string)
+    result = Schema.execute(query_string)
     expected = {
       "data" => {
         "products" => [
@@ -171,7 +167,7 @@ class GraphQL::GraphQLTest < Minitest::Test
         }
       }
     GRAPHQL
-    result = schema_execute(query_string)
+    result = Schema.execute(query_string)
     expected = {
       "data" => {
         "products" => [
@@ -207,7 +203,7 @@ class GraphQL::GraphQLTest < Minitest::Test
         productVariantsCount(id: "2")
       }
     GRAPHQL
-    result = schema_execute(query_string)
+    result = Schema.execute(query_string)
     expected = {
       "data" => {
         "productVariantsCount" => 3
@@ -225,7 +221,7 @@ class GraphQL::GraphQLTest < Minitest::Test
         }
       }
     GRAPHQL
-    result = schema_execute(query_string)
+    result = Schema.execute(query_string)
     expected = {
       "data" => {
         "product" => {
@@ -253,7 +249,7 @@ class GraphQL::GraphQLTest < Minitest::Test
         }
       }
     GRAPHQL
-    result = schema_execute(query_string)
+    result = Schema.execute(query_string)
     expected = {
       "data" => {
         "products" => [
@@ -293,7 +289,7 @@ class GraphQL::GraphQLTest < Minitest::Test
         }
       }
     GRAPHQL
-    result = schema_execute(query_string)
+    result = Schema.execute(query_string)
     expected = {
       "data" => {
         "product" => {
@@ -316,7 +312,7 @@ class GraphQL::GraphQLTest < Minitest::Test
         loadExecutionError
       }
     GRAPHQL
-    result = schema_execute(query_string)
+    result = Schema.execute(query_string)
     expected = {
       "data" => { "constant"=>"constant value", "loadExecutionError" => nil },
       "errors" => [{ "message" => "test error message", "locations"=>[{"line"=>3, "column"=>9}], "path" => ["loadExecutionError"] }],
@@ -333,7 +329,7 @@ class GraphQL::GraphQLTest < Minitest::Test
         incr2: incrementCounter { value, loadValue }
       }
     GRAPHQL
-    result = schema_execute(query_string, context: { counter: [0] })
+    result = Schema.execute(query_string, context: { counter: [0] })
     expected = {
       "data" => {
         "count1" => 0,
@@ -358,7 +354,7 @@ class GraphQL::GraphQLTest < Minitest::Test
         }
       }
     GRAPHQL
-    result = schema_execute(query_string)
+    result = Schema.execute(query_string)
     expected = {
       "data" => {
         "mutation1" => {


### PR DESCRIPTION
GraphQL::ExecutionStrategyTest used to override schema_execute to share the GraphQL::GraphQLTest tests before https://github.com/Shopify/graphql-batch/pull/94 removed the old execution strategies.  So now we can call execute on the schema directly.