### PR TITLE
Try using a field extension for 1.9 interpreter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,6 @@ language: ruby
 rvm:
   - 2.3
   - 2.6
+env:
+  - TESTING_INTERPRETER=true
+  - TESTING_INTERPRETER=false

--- a/Gemfile
+++ b/Gemfile
@@ -4,4 +4,4 @@ gemspec
 # TODO:
 # - Rename `#before_resolve` to `#resolve` in field_extension
 # - Release another `.pre` version
-gem "graphql", github: "rmosolgo/graphql-ruby"
+gem "graphql", github: "rmosolgo/graphql-ruby", branch: "sequential-mutation-root-fields"

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gemspec
-# TODO:
-# - Rename `#before_resolve` to `#resolve` in field_extension
-# - Release another `.pre` version
-gem "graphql", github: "rmosolgo/graphql-ruby", branch: "sequential-mutation-root-fields"
+
+if ENV["TESTING_INTERPRETER"] == "true"
+  gem "graphql", "1.9.0.pre4"
+end

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,7 @@
 source 'https://rubygems.org'
 
 gemspec
+# TODO:
+# - Rename `#before_resolve` to `#resolve` in field_extension
+# - Release another `.pre` version
+gem "graphql", github: "rmosolgo/graphql-ruby"

--- a/lib/graphql/batch.rb
+++ b/lib/graphql/batch.rb
@@ -46,6 +46,3 @@ require_relative "batch/loader"
 require_relative "batch/executor"
 require_relative "batch/setup"
 require_relative "batch/setup_multiplex"
-if defined?(GraphQL::Schema::FieldExtension)
-  require_relative "batch/mutation_field_extension"
-end

--- a/lib/graphql/batch.rb
+++ b/lib/graphql/batch.rb
@@ -17,7 +17,8 @@ module GraphQL
 
     def self.use(schema_defn, executor_class: GraphQL::Batch::Executor)
       schema = schema_defn.target
-      if schema.respond_to?(:interpreter?) && schema.interpreter?
+      if Gem::Version.new(GraphQL::VERSION) >= Gem::Version.new('1.9.0.pre3')
+        require_relative "batch/mutation_field_extension"
         if schema.mutation
           schema.mutation.fields.each do |name, f|
             field = f.metadata[:type_class]

--- a/lib/graphql/batch/mutation_field_extension.rb
+++ b/lib/graphql/batch/mutation_field_extension.rb
@@ -1,0 +1,12 @@
+module GraphQL::Batch
+  class MutationFieldExtension < GraphQL::Schema::FieldExtension
+    def before_resolve(object:, arguments:, **_rest)
+      GraphQL::Batch::Executor.current.clear
+      begin
+        ::Promise.sync(yield(object, arguments))
+      ensure
+        GraphQL::Batch::Executor.current.clear
+      end
+    end
+  end
+end

--- a/lib/graphql/batch/mutation_field_extension.rb
+++ b/lib/graphql/batch/mutation_field_extension.rb
@@ -1,6 +1,6 @@
 module GraphQL::Batch
   class MutationFieldExtension < GraphQL::Schema::FieldExtension
-    def before_resolve(object:, arguments:, **_rest)
+    def resolve(object:, arguments:, **_rest)
       GraphQL::Batch::Executor.current.clear
       begin
         ::Promise.sync(yield(object, arguments))

--- a/test/support/schema.rb
+++ b/test/support/schema.rb
@@ -116,7 +116,12 @@ class QueryType < GraphQL::Schema::Object
 end
 
 class CounterType < GraphQL::Schema::Object
-  field :value, Int, null: false, resolver_method: :object
+  field :value, Int, null: false
+
+  def value
+    object
+  end
+
   field :load_value, Int, null: false
 
   def load_value

--- a/test/support/schema.rb
+++ b/test/support/schema.rb
@@ -116,7 +116,7 @@ class QueryType < GraphQL::Schema::Object
 end
 
 class CounterType < GraphQL::Schema::Object
-  field :value, Int, null: false, method: :object
+  field :value, Int, null: false, resolver_method: :object
   field :load_value, Int, null: false
 
   def load_value
@@ -161,6 +161,9 @@ end
 class Schema < GraphQL::Schema
   query QueryType
   mutation MutationType
+
+  use GraphQL::Execution::Interpreter
+  use GraphQL::Analysis::AST
 
   use GraphQL::Batch
 end

--- a/test/support/schema.rb
+++ b/test/support/schema.rb
@@ -162,8 +162,11 @@ class Schema < GraphQL::Schema
   query QueryType
   mutation MutationType
 
-  use GraphQL::Execution::Interpreter
-  use GraphQL::Analysis::AST
+  if ENV["TESTING_INTERPRETER"] == "true"
+    use GraphQL::Execution::Interpreter
+    # This probably has no effect, but just to get the full test:
+    use GraphQL::Analysis::AST
+  end
 
   use GraphQL::Batch
 end


### PR DESCRIPTION
~~This doesn't quite work yet, and I think it's because of the changes in https://github.com/rmosolgo/graphql-ruby/pull/1984. (Previously, there were cases when execution would proceed eagerly _down_ the tree, but in that PR, it was changed to _always_ resolve each level of depth before proceeding to further depths.)~~ 

~~I think this means that the interpreter has to _hardcode_ handling for mutation root fields, which isn't too surprising. I'll take a look.~~ Fixed by https://github.com/rmosolgo/graphql-ruby/pull/2097

This adds a CI build for 1.9.0.pre4 and and implementation that uses a FieldExtension. I think it will work pretty well, the only problem will be if people do: 

```ruby
# DONT DO THIS, IT WOULD BE BAD 👻
use GraphQL::Batch
mutation(Types::Mutation)
```

It will still work _for now_ because plugins are applied _after_ other configurations. But in the future, there will be no "build" step, and instead, the schema will be constructed just as configured in the source, so it might _start_ breaking. 

We _could_ override `self.mutation(t)` to raise an error, to avoid that configuration error. Would you like to? 

(Also, I realize you may prefer a different path, depending on the conversation over at #93, but I thought I'd code one up just to see how it played out.)