### PR TITLE
Fix compatibility with non-class based mutation root object

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,9 @@ class RecordLoader < GraphQL::Batch::Loader
 end
 ```
 
-Use `GraphQL::Batch` as a plugin in your schema (for graphql >= `1.5.0`).
+Use `GraphQL::Batch` as a plugin in your schema _after_ specifying the mutation
+so that `GraphQL::Batch` can extend the mutation fields to clear the cache after
+they are resolved (for graphql >= `1.5.0`).
 
 ```ruby
 class MySchema < GraphQL::Schema
@@ -67,15 +69,6 @@ MySchema = GraphQL::Schema.define do
 
   GraphQL::Batch.use(self)
 end
-```
-
-##### With `1.9.0`'s `Interpreter` runtime
-
-Add `GraphQL::Batch` _after_ the interpreter, so that `GraphQL::Batch` can detect the interpreter and attach the right integrations:
-
-```ruby
-use GraphQL::Execution::Interpreter
-use GraphQL::Batch
 ```
 
 #### Field Usage

--- a/test/support/schema.rb
+++ b/test/support/schema.rb
@@ -157,10 +157,30 @@ class NoOpMutation < GraphQL::Schema::Mutation
   end
 end
 
-class MutationType < GraphQL::Schema::Object
-  field :increment_counter, mutation: IncrementCounterMutation
-  field :counter_loader, mutation: CounterLoaderMutation
-  field :no_op, mutation: NoOpMutation
+if ENV["TESTING_INTERPRETER"] == "true"
+  class MutationType < GraphQL::Schema::Object
+    field :increment_counter, mutation: IncrementCounterMutation
+    field :counter_loader, mutation: CounterLoaderMutation
+    field :no_op, mutation: NoOpMutation
+  end
+else
+  MutationType = GraphQL::ObjectType.define do
+    name "Mutation"
+
+    field :incrementCounter, CounterType.to_non_null_type do
+      resolve ->(_, _, ctx) { ctx[:counter][0] += 1; CounterLoader.load(ctx[:counter]) }
+    end
+
+    field :counterLoader, !types.Int do
+      resolve ->(_, _, ctx) {
+        CounterLoader.load(ctx[:counter])
+      }
+    end
+
+    field :noOp, QueryType.to_non_null_type do
+      resolve ->(_, _, ctx) { Hash.new }
+    end
+  end
 end
 
 class Schema < GraphQL::Schema


### PR DESCRIPTION
I think this fixes #101, @Mange can you confirm that?
cc @rmosolgo 

## Problem

We assumed that we could always use field extensions with version 1.9 of the graphql gem but that doesn't work if the fields are defined on a mutation root object type that doesn't use the new class-based API.

## Solution

Make the use of field extensions conditional upon having a `schema.mutation.metadata[:type_class]`.  I also changed the test schema to use a non-class based mutation root when not testing with the interpreter.

I also noticed that the README documentation was saying that `use GraphQL::Batch` needed to follow `use GraphQL::Execution::Interpreter`, but it is actually the `mutation` line that it needs to follow.