### PR TITLE
Update plugin for 1.10-dev

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,5 @@ source 'https://rubygems.org'
 gemspec
 
 if ENV["TESTING_INTERPRETER"] == "true"
-  gem "graphql", "1.9.0.pre4"
+  gem "graphql", "1.10.0.pre2"
 end


### PR DESCRIPTION
graphql 1.10.0 will change the structure of class-based schemas so that they _don't_ delegate to `.define`-style singletons anymore. Naturally, this breaks stuff 😅 . 

I've added a 1.10.0.pre2 build to CI (which should cover all the structural changes) and updated the code to pass.

Fixes #115