### PR TITLE
Bump the rake dev dependency

### DIFF
--- a/graphql-batch.gemspec
+++ b/graphql-batch.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "promise.rb", "~> 0.7.2"
 
   spec.add_development_dependency "byebug" if RUBY_ENGINE == 'ruby'
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake", ">= 12.3.3"
   spec.add_development_dependency "minitest"
 end


### PR DESCRIPTION
## Problem

Github had an alert on a vulnerability in the development dependency rake (https://github.com/advisories/GHSA-jppv-gw3r-w3q8).

## Solution

Use the recommended constraint `spec.add_development_dependency "rake", ">= 12.3.3"` since we don't have any incompatibilities with newer versions of rake.