### PR TITLE
Fix ruby 2.7 keyword arguments warning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 rvm:
   - 2.3
-  - 2.6
+  - 2.7
 env:
   -
     GRAPHQL_VERSION: 1.9.19

--- a/lib/graphql/batch/loader.rb
+++ b/lib/graphql/batch/loader.rb
@@ -8,7 +8,7 @@ module GraphQL::Batch
         end
       RUBY
     else
-      def self.for(*group_args, **group_kwargs)
+      def self.for(*group_args)
         current_executor.loader(loader_key_for(*group_args)) { new(*group_args) }
       end
     end


### PR DESCRIPTION
Fixes #126

## Problem

GraphQL::Batch::Loader was using `*group_args` for forwarding arguments which won't forward keyword arguments in the future which may be used by the loader (e.g. we do that in the RecordLoader example).

## Solution

Use `*group_args` for argument forwarding for older ruby versions, since passing keyword arguments an initializer that doesn't take them causes problems for old versions of ruby.

As an optimization, I used `...` syntax for argument forwarding for MRI ruby 2.7+ which avoids some object allocation for the splat parameters.  I had to eval the ruby code using the new syntax to avoid causing parsing problems for older versions of ruby.

I also changed the CI config to test ruby 2.7.