### PR TITLE
Adding examples for Active Storage Loader and Postgres Window Loader

### DIFF
--- a/examples/active_storage_loader.rb
+++ b/examples/active_storage_loader.rb
@@ -1,0 +1,52 @@
+####
+# This is a loader for has_one_attached Active Storage attachments
+# To load a variant for an attachment, 2 queries are required
+# Using preloading via the includes method.
+####
+
+####
+# The model with an attached image
+####
+
+# class Event < ApplicationRecord
+#   has_one_attached :image
+# end
+
+####
+# An example data type using the AttachmentLoader
+####
+
+# class Types::EventType < Types::BaseObject
+#   graphql_name 'Event'
+#
+#   field :id, ID, null: false
+#   field :image, String, null: true
+#
+#   def image
+#     AttachmentLoader.for(:Event, :image).load(object.id).then do |image|
+#       Rails.application.routes.url_helpers.url_for(
+#         image.variant({ quality: 75 })
+#       )
+#     end
+#   end
+# end
+
+class ActiveStorageLoader < GraphQL::Batch::Loader
+  attr_reader :record_type, :attachment_name
+
+  def initialize(record_type, attachment_name)
+    @record_type = record_type
+    @attachment_name = attachment_name
+  end
+
+  def perform(record_ids)
+    # find records and fulfill promises
+    ActiveStorage::Attachment.includes(:blob).where(
+      record_type: record_type, record_id: record_ids, name: attachment_name
+    )
+      .each { |record| fulfill(record.record_id, record) }
+
+    # fulfill unfilfilled records
+    record_ids.each { |id| fulfill(id, nil) unless fulfilled?(id) }
+  end
+end

--- a/examples/window_key_loader.rb
+++ b/examples/window_key_loader.rb
@@ -1,0 +1,80 @@
+####
+# This is a has_many loader which takes advantage of Postgres'
+# windowing functionality to load the first N records for
+# a given relationship.
+####
+
+####
+# An example data type using the WindowKeyLoader
+####
+
+# class Types::CategoryType < Types::BaseObject
+#   graphql_name 'Category'
+
+#   field :id, ID, null: false
+#   field :events, [Types::EventType], null: false do
+#     argument :first, Int, required: false, default_value: 5
+#   end
+
+#   def events(first:)
+#     WindowKeyLoader.for(
+#       Event,
+#       :category_id,
+#       limit: first, order_col: :start_time, order_dir: :desc
+#     ).load(object.id)
+#   end
+# end
+
+####
+# The SQL that is produced
+####
+
+# SELECT
+#   "events".*
+# FROM (
+#   SELECT
+#     "events".*,
+#     row_number() OVER (PARTITION BY category_id ORDER BY start_time DESC) AS rank
+#   FROM
+#     "events"
+#   WHERE
+#     "events"."category_id" IN(1, 2, 3, 4, 5)) AS events
+# WHERE (rank <= 5)
+
+class WindowKeyLoader < GraphQL::Batch::Loader
+  attr_reader :model, :foreign_key, :limit, :order_col, :order_dir
+
+  def initialize(model, foreign_key, limit:, order_col:, order_dir: :asc)
+    @model = model
+    @foreign_key = foreign_key
+    @limit = limit
+    @order_col = order_col
+    @order_dir = order_dir
+  end
+
+  def perform(foreign_ids)
+    # build the sub-query, limiting results by foreign key at this point
+    # we don't want to execute this query but get its SQL to be used later
+    ranked_from =
+      model.select(
+        "*",
+        "row_number() OVER (
+          PARTITION BY #{foreign_key} ORDER BY #{order_col} #{order_dir}
+        ) as rank"
+      ).where(foreign_key => foreign_ids).to_sql
+
+    # use the sub-query from above to query records which have a rank
+    # value less than or equal to our limit
+    records =
+      model.from("(#{ranked_from}) as #{model.table_name}").where(
+        "rank <= #{limit}"
+      ).to_a
+
+    # match records and fulfill promises
+    foreign_ids.each do |foreign_id|
+      matching_records =
+        records.select { |r| foreign_id == r.send(foreign_key) }
+      fulfill(foreign_id, matching_records)
+    end
+  end
+end


### PR DESCRIPTION
I love when a project has a ton of examples that can be used and extended. Example: https://github.com/zeit/next.js/tree/canary/examples

I wanted to add 2 examples that solve somewhat challenging batch issues:

- Loading `has_many` relationships where you want the first N records. This can be accomplished using window functions in Postgres.
- Loading Active Storage attachments (can often produce 2N + 1 queries).