### PR TITLE
Drop support for define mutation tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,6 @@
 name: Tests
 
-on:
-  push
+on: push
 
 jobs:
   test:
@@ -10,18 +9,11 @@ jobs:
       fail-fast: false
       matrix:
         ruby: [2.3, 2.7, 3.0]
-        graphql_version: ['1.9.19', '1.11.6']
-        exclude:
-          - graphql_version: '1.9.19'
-            ruby: 3.0
     steps:
-    - uses: actions/checkout@v2
-    - uses: ruby/setup-ruby@v1
-      with:
-        bundler-cache: true
-        ruby-version: ${{ matrix.ruby }}
-      env:
-        GRAPHQL_VERSION: ${{ matrix.graphql_version }}
-        TESTING_LEGACY_DEFINITION_LAYER: ${{ startsWith(matrix.graphql_version, '1.9') }}
-    - run: bundle install
-    - run: bundle exec rake
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+          ruby-version: ${{ matrix.ruby }}
+      - run: bundle install
+      - run: bundle exec rake

--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,5 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'graphql', ENV['GRAPHQL_VERSION'] if ENV['GRAPHQL_VERSION']
+gem 'graphql'
 gem 'rubocop', '~> 0.78.0', require: false

--- a/graphql-batch.gemspec
+++ b/graphql-batch.gemspec
@@ -18,9 +18,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.metadata['allowed_push_host'] = "https://rubygems.org"
-
-  spec.add_runtime_dependency "graphql", ">= 1.3", "< 2"
+  spec.add_runtime_dependency "graphql", ">= 1.10", "< 2"
   spec.add_runtime_dependency "promise.rb", "~> 0.7.2"
 
   spec.add_development_dependency "byebug" if RUBY_ENGINE == 'ruby'

--- a/lib/graphql/batch.rb
+++ b/lib/graphql/batch.rb
@@ -15,31 +15,21 @@ module GraphQL
       end
     end
 
-    def self.use(schema_defn, executor_class: GraphQL::Batch::Executor)
-      # Support 1.10+ which passes the class instead of the definition proxy
-      schema = schema_defn.is_a?(Class) ? schema_defn : schema_defn.target
-      current_gem_version = Gem::Version.new(GraphQL::VERSION)
-      if current_gem_version >= Gem::Version.new("1.6.0")
-        instrumentation = GraphQL::Batch::SetupMultiplex.new(schema, executor_class: executor_class)
-        schema_defn.instrument(:multiplex, instrumentation)
-        if schema.mutation
-          if current_gem_version >= Gem::Version.new('1.9.0.pre3') &&
-              (schema.mutation.is_a?(Class) || schema.mutation.metadata[:type_class])
-            require_relative "batch/mutation_field_extension"
-            schema.mutation.fields.each do |name, f|
-              field = f.respond_to?(:type_class) ? f.type_class : f.metadata[:type_class]
-              field.extension(GraphQL::Batch::MutationFieldExtension)
-            end
-          else
-            schema_defn.instrument(:field, instrumentation)
+    def self.use(schema, executor_class: GraphQL::Batch::Executor)
+      instrumentation = GraphQL::Batch::SetupMultiplex.new(schema, executor_class: executor_class)
+      schema.instrument(:multiplex, instrumentation)
+      if schema.mutation
+        if schema.mutation.is_a?(Class) || schema.mutation.metadata[:type_class]
+          require_relative "batch/mutation_field_extension"
+          schema.mutation.fields.each do |name, f|
+            field = f.respond_to?(:type_class) ? f.type_class : f.metadata[:type_class]
+            field.extension(GraphQL::Batch::MutationFieldExtension)
           end
+        else
+          schema.instrument(:field, instrumentation)
         end
-      else
-        instrumentation = GraphQL::Batch::Setup.new(schema, executor_class: executor_class)
-        schema_defn.instrument(:query, instrumentation)
-        schema_defn.instrument(:field, instrumentation)
       end
-      schema_defn.lazy_resolve(::Promise, :sync)
+      schema.lazy_resolve(::Promise, :sync)
     end
   end
 end

--- a/test/support/schema.rb
+++ b/test/support/schema.rb
@@ -157,41 +157,18 @@ class NoOpMutation < GraphQL::Schema::Mutation
   end
 end
 
-if ENV["TESTING_LEGACY_DEFINITION_LAYER"] != "true"
-  class MutationType < GraphQL::Schema::Object
-    field :increment_counter, mutation: IncrementCounterMutation
-    field :counter_loader, mutation: CounterLoaderMutation
-    field :no_op, mutation: NoOpMutation
-  end
-else
-  MutationType = GraphQL::ObjectType.define do
-    name "Mutation"
-
-    field :incrementCounter, CounterType.to_non_null_type do
-      resolve ->(_, _, ctx) { ctx[:counter][0] += 1; CounterLoader.load(ctx[:counter]) }
-    end
-
-    field :counterLoader, !types.Int do
-      resolve ->(_, _, ctx) {
-        CounterLoader.load(ctx[:counter])
-      }
-    end
-
-    field :noOp, QueryType.to_non_null_type do
-      resolve ->(_, _, ctx) { Hash.new }
-    end
-  end
+class MutationType < GraphQL::Schema::Object
+  field :increment_counter, mutation: IncrementCounterMutation
+  field :counter_loader, mutation: CounterLoaderMutation
+  field :no_op, mutation: NoOpMutation
 end
 
 class Schema < GraphQL::Schema
   query QueryType
   mutation MutationType
 
-  if ENV["TESTING_LEGACY_DEFINITION_LAYER"] != "true"
-    use GraphQL::Execution::Interpreter
-    # This probably has no effect, but just to get the full test:
-    use GraphQL::Analysis::AST
-  end
-
+  use GraphQL::Execution::Interpreter
+  # This probably has no effect, but just to get the full test:
+  use GraphQL::Analysis::AST
   use GraphQL::Batch
 end


### PR DESCRIPTION
The GraphQL ruby gem dropped support for define mutations between version v1.9.19 and v1.10.0. This bumps the required version to the latest and removes the legacy test. 

Note: initial proposed in https://github.com/Shopify/graphql-batch/pull/120

This PR is a re-build for this https://github.com/Shopify/graphql-batch/pull/121 to fix CI (hopefully).