### PR TITLE
CI: Workaround YAML gotcha in Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,11 +9,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.3, 2.7, 3.0]
+        ruby: [2.3, 2.7, '3.0']
         graphql_version: ['1.9.19', '1.11.6']
         exclude:
           - graphql_version: '1.9.19'
-            ruby: 3.0
+            ruby: '3.0'
     steps:
     - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1


### PR DESCRIPTION
To avoid unexpectedly stop testing Ruby 3.0 when Ruby 3.1 is released.

See actions/runner#849

At https://github.com/Shopify/graphql-batch/runs/1691443768?check_suite_focus=true#step:3:4 we can see that the setup-ruby action ran with just `3` as the input and not `3.0`.