### PR TITLE
Fix errors in examples

### DIFF
--- a/examples/active_storage_loader.rb
+++ b/examples/active_storage_loader.rb
@@ -35,7 +35,7 @@ class ActiveStorageLoader < GraphQL::Batch::Loader
   attr_reader :record_type, :attachment_name
 
   def initialize(record_type, attachment_name)
-    super
+    super()
     @record_type = record_type
     @attachment_name = attachment_name
   end

--- a/examples/association_loader.rb
+++ b/examples/association_loader.rb
@@ -5,7 +5,7 @@ class AssociationLoader < GraphQL::Batch::Loader
   end
 
   def initialize(model, association_name)
-    super
+    super()
     @model = model
     @association_name = association_name
     validate

--- a/examples/http_loader.rb
+++ b/examples/http_loader.rb
@@ -38,7 +38,7 @@
 module Loaders
   class HTTPLoader < GraphQL::Batch::Loader
     def initialize(host:, size: 4, timeout: 4)
-      super
+      super()
       @host = host
       @size = size
       @timeout = timeout

--- a/examples/record_loader.rb
+++ b/examples/record_loader.rb
@@ -1,6 +1,6 @@
 class RecordLoader < GraphQL::Batch::Loader
   def initialize(model, column: model.primary_key, where: nil)
-    super
+    super()
     @model = model
     @column = column.to_s
     @column_type = model.type_for_attribute(@column)

--- a/examples/window_key_loader.rb
+++ b/examples/window_key_loader.rb
@@ -45,7 +45,7 @@ class WindowKeyLoader < GraphQL::Batch::Loader
   attr_reader :model, :foreign_key, :limit, :order_col, :order_dir
 
   def initialize(model, foreign_key, limit:, order_col:, order_dir: :asc)
-    super
+    super()
     @model = model
     @foreign_key = foreign_key
     @limit = limit


### PR DESCRIPTION
When using the loader of examples, the following error occurred.

```
wrong number of arguments (given 2, expected 0)
/app/app/loader/association_loader.rb:10:in `initialize'
```

The problem is passing arguments to the `super`, so I fixed it so that no arguments are passed.
