### PR TITLE
Clear loader cache in Mutation#after_resolve

### DIFF
--- a/lib/graphql/batch/mutation_field_extension.rb
+++ b/lib/graphql/batch/mutation_field_extension.rb
@@ -8,5 +8,10 @@ module GraphQL::Batch
         GraphQL::Batch::Executor.current.clear
       end
     end
+
+    def after_resolve(value:, **_rest)
+      GraphQL::Batch::Executor.current.clear
+      value
+    end
   end
 end


### PR DESCRIPTION
The `resolve` method of a Mutation can make changes to the DB that
invalidate any cached Loader results. So, the cache should be cleared
after the resolve method has completed, and before any nested fields on
the Mutation query are resolved.

In our codebase, this causes authorization errors if the Mutation
removes a member from a list/connection, and the client requests that
same list field as part of the mutation response. Since the Loader
cached the pre-mutation result, the wrong data is returned to the
client.

Note: At first, I was expecting the usage of `::Promise.sync` in the `resolve` method to handle this case, but when I step through the code with puts/byebug, I observe that the `authorized?` or `resolve` methods of the mutation are not called at all until after the `Promise.sync` call is complete. I feel its possible im misunderstanding something.