### PR TITLE
Fix AssociationLoader Rails 7 Deprecation Warning

### DIFF
--- a/examples/association_loader.rb
+++ b/examples/association_loader.rb
@@ -36,7 +36,7 @@ class AssociationLoader < GraphQL::Batch::Loader
   end
 
   def preload_association(records)
-    ::ActiveRecord::Associations::Preloader.new.preload(records, @association_name)
+    ::ActiveRecord::Associations::Preloader.new(records: records, associations: @association_name).call
   end
 
   def read_association(record)


### PR DESCRIPTION
Currently running this example code with rails 7 yields the following warning:

```
DEPRECATION WARNING: `preload` is deprecated and will be removed in Rails 7.0. Call `Preloader.new(kwargs).call` instead.
```

Updating the preloader code to use kwargs and call silences the warning.