### PR TITLE
Prep for graphql-ruby 2.0

### DIFF
--- a/test/support/schema.rb
+++ b/test/support/schema.rb
@@ -167,7 +167,5 @@ class Schema < GraphQL::Schema
   query QueryType
   mutation MutationType
 
-  use GraphQL::Execution::Interpreter
-  use GraphQL::Analysis::AST
   use GraphQL::Batch
 end


### PR DESCRIPTION
I'm removing a bunch of deprecated code in graphql-ruby 2.0 and I want to make sure graphql-batch will be good-to-go on that version. 

I ran the tests with graphql 1.13.x. These two configs gave warnings (to remove them), so I removed them. Then I pointed this project's gemfile to use `rmosolgo/graphql-ruby` (the 2.0 branch is on master now), and everything worked fine :+1: So, I think the gem's source is 2.0-ready, and just the tests needed an update.