### PR TITLE
Allow graphql 2.0, add it to the build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.4, 2.7, '3.0']
-        graphql_version: ['~> 1.10.0', '~> 1.13']
+        ruby: [2.4, 2.7, '3.1']
+        graphql_version: ['~> 1.10.0', '~> 1.13', '~> 2.0']
     steps:
     - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1

--- a/graphql-batch.gemspec
+++ b/graphql-batch.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
 
   spec.metadata['allowed_push_host'] = "https://rubygems.org"
 
-  spec.add_runtime_dependency "graphql", ">= 1.10", "< 2"
+  spec.add_runtime_dependency "graphql", ">= 1.10", "< 3"
   spec.add_runtime_dependency "promise.rb", "~> 0.7.2"
 
   spec.add_development_dependency "byebug" if RUBY_ENGINE == 'ruby'


### PR DESCRIPTION
I'm not sure how y'all actually want to use this version parameter, but I noticed it prevents GraphQL-Ruby 2.0. I added that new version to the build to double-check that it still worked, and while I was there, also bumped the top ruby version. Feel free to take any of this that you like, or let me know if there's anything I can change to make it more helpful!