### PR TITLE
Improve Shapes Friendliness of Batch::Loader

### DIFF
--- a/lib/graphql/batch/loader.rb
+++ b/lib/graphql/batch/loader.rb
@@ -44,6 +44,13 @@ module GraphQL::Batch
 
     attr_accessor :loader_key, :executor
 
+    def initialize
+      @loader_key = nil
+      @executor = nil
+      @queue = nil
+      @cache = nil
+    end
+
     def load(key)
       cache[cache_key(key)] ||= begin
         queue << key


### PR DESCRIPTION
For optimal performance in Ruby 3.2, it is preferable to define instance variables in a consistent order.

Based on production data, it seems that Batch::Loader is one of the main offenders in our app:

```
Shape Edges Report
-----------------------------------
       169  @cache
       130  @queue
       127  @executor
       125  @sql_counter
       119  @loader_key
```