### PR TITLE
Add support for Ruby 3.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.4, 2.7, '3.1']
+        ruby: [2.4, 2.7, '3.1', '3.2']
         graphql_version: ['~> 1.10.0', '~> 1.13', '~> 2.0']
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby: [2.4, 2.7, '3.1', '3.2']
-        graphql_version: ['~> 1.10.0', '~> 1.13', '~> 2.0']
+        graphql_version: ['~> 1.12.18', '~> 1.13', '~> 2.0']
     steps:
     - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1

--- a/graphql-batch.gemspec
+++ b/graphql-batch.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
 
   spec.metadata['allowed_push_host'] = "https://rubygems.org"
 
-  spec.add_runtime_dependency "graphql", ">= 1.10", "< 3"
+  spec.add_runtime_dependency "graphql", ">= 1.12.18", "< 3"
   spec.add_runtime_dependency "promise.rb", "~> 0.7.2"
 
   spec.add_development_dependency "byebug" if RUBY_ENGINE == 'ruby'


### PR DESCRIPTION
These changes adds support for Ruby 3.2 by bumping the minimum required version of `graphql` from `1.10.0` to `1.12.18` which fixes a Ruby 3.2 incompatibility related to the use of include in refinements as fixed in this PR:
https://github.com/rmosolgo/graphql-ruby/pull/3674