### PR TITLE
Add a custom wrapper around #perform

### DIFF
--- a/lib/graphql/batch/loader.rb
+++ b/lib/graphql/batch/loader.rb
@@ -66,10 +66,19 @@ module GraphQL::Batch
       return if resolved?
       load_keys = queue
       @queue = nil
-      perform(load_keys)
+
+      around_perform do
+        perform(load_keys)
+      end
+
       check_for_broken_promises(load_keys)
     rescue => err
       reject_pending_promises(load_keys, err)
+    end
+
+    # Interface to add custom code for purposes such as instrumenting the performance of the loader.
+    def around_perform
+      yield
     end
 
     # For Promise#sync

--- a/lib/graphql/batch/version.rb
+++ b/lib/graphql/batch/version.rb
@@ -1,5 +1,5 @@
 module GraphQL
   module Batch
-    VERSION = "0.5.2"
+    VERSION = "0.5.3"
   end
 end


### PR DESCRIPTION
TL;DR This PR adds a wrapper method around the `#perform` method. This allows us to wrap the `#perform` method within code blocks that would help with measuring the performance in terms of time taken or the number of sql queries executed or anything else

Today, we have to override the `#resolve` method as demonstrated by the example below.
```ruby
class BaseLoader < GraphQL::Batch::Loader
    def resolve
      return if resolved?
      load_keys = queue
      @queue = nil

      instrument_sql_requests do
        perform(load_keys)
      end

      check_for_broken_promises(load_keys)
    rescue => err
      reject_pending_promises(load_keys, err)
    end

    def instrument_sql_requests
      SQLCounter.run { yield }
    end
end
```

With the proposed changes, the `#resolve` method does not need to be overridden and a system can call multiple wrappers if required.
```ruby
class BaseLoader < GraphQL::Batch::Loader
  def custom_wrapper
    instrument_sql_queries do
      run_tracer do
        yield
      end
    end
  end

  def instrument_sql_queries
    SQLCounter.run { super }
  end

  def run_tracer
    CustomTracer.run { super }
  end
end
```

### How did this come up?

Today we override the `#resolve` method. But we were looking to add tracing as well. While the tracing can be added within the `#resolve` method, it'd be nicer to add a shared implementation for this gem within Opentelemetry ([tracking issue](https://github.com/open-telemetry/opentelemetry-ruby-contrib/issues/457)).

This is a non breaking change and should not cause any issues. This PR also releases v0.5.3