### PR TITLE
Make executor_class optional in trace class

### DIFF
--- a/lib/graphql/batch/setup_multiplex.rb
+++ b/lib/graphql/batch/setup_multiplex.rb
@@ -14,7 +14,7 @@ module GraphQL::Batch
     end
 
     module Trace
-      def initialize(executor_class:, **_rest)
+      def initialize(executor_class: nil, **_rest)
         @executor_class = executor_class
         super
       end


### PR DESCRIPTION
Otherwise `Schema.new_trace` will require `executor_class` as a keyword arg which is the wrong place to pass it in.

@rmosolgo should `execute_multiplex` check for the existence of `executor_class` or is this existing one enough? https://github.com/Shopify/graphql-batch/blob/8e88b28d10a894d3bbb221095424fc948e62bccd/lib/graphql/batch/executor.rb#L22-L24