### PR TITLE
Priming the cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,22 @@ def product(id:)
 end
 ```
 
+### Priming the Cache
+
+You can prime the loader cache with a specific value, which can be useful in certain situations.
+
+```ruby
+def liked_products
+  liked_products = Product.where(liked: true).load
+  liked_products.each do |product|
+    RecordLoader.for(Product).prime(product.id, product)
+  end
+end
+```
+
+Priming will add key/value to the loader cache only if it didn't exist before.
+
+
 ## Unit Testing
 
 Your loaders can be tested outside of a GraphQL query by doing the

--- a/lib/graphql/batch/loader.rb
+++ b/lib/graphql/batch/loader.rb
@@ -62,6 +62,10 @@ module GraphQL::Batch
       ::Promise.all(keys.map { |key| load(key) })
     end
 
+    def prime(key, value)
+      cache[cache_key(key)] ||= ::Promise.resolve(value).tap { |p| p.source = self }
+    end
+
     def resolve #:nodoc:
       return if resolved?
       load_keys = queue


### PR DESCRIPTION
Sometimes data is loaded through some means, which will also later be loaded by an independent batch data loader. It can be convenient to then prime the cache of that data data loader with the already loaded data, to remove redundant calls.

The use-case I have can be summarized by this query:

```
query {
  shopsFollowed(first: 10) {
    nodes {
      id
      followedByMe
    }
  }
}
```

The `shopsFollowed` resolver performs a query to load 10 shops that the current user follows. This is returned as the `Shop` type, which is used extensively in the API. The `Shop.followedByMe` field returns a boolean of whether the current user follows the shop. It's backed by a custom batch data loader.

For the specific `shopsFollowed` use-case, we know that all the shops returned are followed by the current user, so there's no need for the custom batch data loader to load this again.

With `prime` we can have the `shopsFollowed` resolver pre-populate this information on the loader.

This is available in other graphql batch data loader libraries, see e.g.

 - https://github.com/graphql/dataloader?tab=readme-ov-file#primekey-value
 - https://github.com/graph-gophers/dataloader/blob/ab736ad423a90b8560fb932a3c523693b52c8f35/dataloader.go#L369