### PR TITLE
Improve ActiveStorageLoader example for STI models

### DIFF
--- a/examples/active_storage_loader_sti.rb
+++ b/examples/active_storage_loader_sti.rb
@@ -1,0 +1,90 @@
+####
+# This is a loader for Active Storage attachments,
+# a little bit more complex than the `active_storage_loader.rb` example
+# because it supports STI (Single Table Inheritance) models where the
+# `has_one_attached` or `has_many_attached` is defined on any of the ancestor classes of the model.
+
+####
+# The model with an attached image and many attached pictures:
+####
+
+# class Event < ApplicationRecord
+#   has_one_attached :image
+#   has_many_attached :pictures
+# end
+
+####
+# An example data type using the AttachmentLoader:
+####
+
+# class Types::EventType < Types::BaseObject
+#   graphql_name 'Event'
+#
+#   field :id, ID, null: false
+#   field :image, String, null: true
+#   field :pictures, String, null: true
+#
+#   def image
+#     AttachmentLoader.for(:Event, :image).load(object.id).then do |image|
+#       Rails.application.routes.url_helpers.url_for(
+#         image.variant({ quality: 75 })
+#       )
+#     end
+#   end
+#
+#   def pictures
+#     AttachmentLoader.for(:Event, :pictures, association_type: :has_many_attached).load(object.id).then do |pictures|
+#       pictures.map do |picture|
+#         Rails.application.routes.url_helpers.url_for(
+#           picture.variant({ quality: 75 })
+#         )
+#       end
+#     end
+#   end
+# end
+
+class ActiveStorageLoader < GraphQL::Batch::Loader
+  attr_reader :record_type, :attachment_name, :association_type
+
+  def initialize(record_type, attachment_name, association_type: :has_one_attached)
+    super()
+    @record_type = record_type
+    @attachment_name = attachment_name
+    @association_type = association_type
+  end
+
+  def perform(record_ids)
+    attachments = ActiveStorage::Attachment.includes(:blob, :record).where(
+      record_type: ancestors_record_types, record_id: record_ids, name: attachment_name
+    )
+
+    if @association_type == :has_one_attached
+      attachments.each do |attachment|
+        fulfill(attachment.record_id, attachment)
+      end
+
+      record_ids.each { |id| fulfill(id, nil) unless fulfilled?(id) }
+    else
+      record_ids.each do |record_id|
+        fulfill(record_id, attachments.select { |attachment| attachment.record_id == record_id })
+      end
+    end
+  end
+
+  private
+
+  def ancestors_record_types
+    # Get all ancestor classes of record_type that are descendants of ActiveRecord::Base
+    # This is necessary because in a Single Table Inheritance (STI) setup,
+    # the `has_one_attached` or `has_many_attached`
+    # could be defined on any of the ancestor classes of the model, not just the model itself,
+    # which determines whether the `record_type` string is stored as the model's class name
+    # or the ancestor's class name.
+    # So we for any of the ancestor classes to ensure we don't miss the attachment
+    # we are looking for:
+
+    @record_type.to_s.constantize.ancestors.select do |ancestor|
+      ancestor < ActiveRecord::Base
+    end.map(&:to_s)
+  end
+end


### PR DESCRIPTION
# Update ActiveStorageLoader to Support STI Models

## Description:

This pull request updates the ActiveStorageLoader example to make it smarter so that it better supports Single Table Inheritance (STI) models.

## Long context:

Previously, the ActiveStorageLoader class assumed that the `record_type` (the model that has the attachment) was always the class where the `has_one_attached` or `has_many_attached` was defined. However, in an STI setup, the attachment could be defined on any of the ancestor classes of the model, not just the model itself.

For example, consider the following STI setup:

```ruby 
class Vehicle < ApplicationRecord
  has_one_attached :document
end

class Car < Vehicle; end
class Truck < Vehicle; end
```

In this case, both `Car` and `Truck` models inherit the document attachment from the Vehicle parent class. If we were to use the `ActiveStorageLoader` with `record_type` set to `"Car"` or `"Truck"`, it would not find the attachment, because it's defined on the `Vehicle` parent class, so the `record_type` is actually `"Vehicle"`.

The following would NOT load the attachment:
```ruby 
Loaders::ActiveStorageLoader.for("Car", "document").load(id)
```

In plain sight this might seem easily avoidable by simply calling the `ActiveStorageLoader` with `Vehicle`. However, there are times where we call the loader dynamically from a more complex context so it's better to make the `ActiveStorageLoader` so that it can be called with a subclass and it would still find the attachment. 

For instance, you might have an extension to load the attachment blob url:

```ruby 
# Usage example:
# 
#  field :document_url, String, null: true, extension: Extensions::AttachmentUrlField, attachment: :document

module Extensions
  class AttachmentUrlField < GraphQL::Schema::FieldExtension
    attr_reader :attachment_name

    def apply
      @attachment_name = options&.[](:attachment) || field.original_name.to_s.sub(/_url$/, '')
    end

    def resolve(object:, arguments:, **_rest)
      record = object.object # Because object is a `Field` instance, not the ActiveRecord.
      id = record.id
      class_sym = record.class.name.to_sym # <- !!! This would be "Car" instead of "Vehicle"
      variant = arguments[:variant]

      Loaders::ActiveStorageLoader.for(class_sym, attachment_name).load(id).then do |value|
        next if value.nil?

        variant_blob = variant ? value.variant(variant.to_sym) : value
        Rails.application.routes.url_helpers.url_for(variant_blob)
      end
    end
  end
end
```

---

## Solution 

To address this, this PR updates the ActiveStorageLoader class to get all ancestor classes of `record_type` that are descendants of `ActiveRecord::Base`. This ensures that we correctly handle attachments for all possible `record_types`, whether it's the model itself or any of its ancestors in the STI hierarchy.
