### PR TITLE
Fix loader for kwargs mutation ruby4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.7, 3.0, 3.1, 3.2, 3.3]
+        ruby: [2.7, 3.0, 3.1, 3.2, 3.3, 3.4, 4.0]
         graphql_version: ['~> 1.13', '~> 2.0']
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/lib/graphql/batch/loader.rb
+++ b/lib/graphql/batch/loader.rb
@@ -1,10 +1,11 @@
 module GraphQL::Batch
   class Loader
-    # Use new argument forwarding syntax if available as an optimization
     if RUBY_ENGINE && Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.7")
       class_eval(<<~RUBY, __FILE__, __LINE__ + 1)
-        def self.for(...)
-          current_executor.loader(loader_key_for(...)) { new(...) }
+        def self.for(*group_args, **group_kwargs, &block)
+          current_executor.loader(loader_key_for(*group_args, **group_kwargs)) do
+            new(*group_args, **group_kwargs, &block)
+          end
         end
       RUBY
     else

--- a/test/loader_test.rb
+++ b/test/loader_test.rb
@@ -63,6 +63,21 @@ class GraphQL::Batch::LoaderTest < Minitest::Test
     end
   end
 
+  class KwargsGroupCountLoader < GraphQL::Batch::Loader
+    def initialize(group, key: :id, preload: true, not_found_value: nil, **conditions)
+    end
+
+    def perform(keys)
+      keys.each { |key| fulfill(key, keys.size) }
+    end
+
+    # Mimics RecordLoader.load: destructures kwargs with defaults and **rest,
+    # then re-passes them to .for()
+    def self.load_via_intermediary(group, load_key, key: :id, preload: true, not_found_value: nil, **conditions)
+      self.for(group, key: key, preload: preload, not_found_value: not_found_value, **conditions).load(load_key)
+    end
+  end
+
   def setup
     GraphQL::Batch::Executor.current = GraphQL::Batch::Executor.new
   end
@@ -90,6 +105,27 @@ class GraphQL::Batch::LoaderTest < Minitest::Test
       GroupCountLoader.for('two').load(:b),
     ])
     assert_equal [2, 1, 2], group.sync
+  end
+
+  # Reproduces a Ruby 4.0 bug where kwargs forwarded through ... get mutated
+  # when they were destructured and re-assembled by an intermediary method.
+  # Direct .for() calls don't trigger this; the kwargs must pass through a
+  # method that destructures them into named parameters (with defaults and
+  # **rest) then re-passes them to .for().
+  def test_query_group_with_kwargs_via_intermediary
+    group = Promise.all([
+      KwargsGroupCountLoader.load_via_intermediary('two', :a),
+      KwargsGroupCountLoader.load_via_intermediary('one', :a),
+      KwargsGroupCountLoader.load_via_intermediary('two', :b),
+    ])
+    assert_equal [2, 1, 2], group.sync
+  end
+
+  def test_loader_key_not_mutated_by_for_via_intermediary
+    KwargsGroupCountLoader.load_via_intermediary('test', :a).sync
+    loader = GraphQL::Batch::Executor.current.instance_variable_get(:@loaders).values.first
+    expected_kwargs = { key: :id, preload: true, not_found_value: nil }
+    assert_equal expected_kwargs, loader.loader_key[1]
   end
 
   def test_query_many


### PR DESCRIPTION
Hello!

I'm creating this PR because I've found a problem using this gem with Ruby 4 and a specific way of using loaders. The problem seems with the use of `...` operator forwarding in ruby 4 and the loader class.

On Ruby 4.0, when kwargs are destructured by a caller method and re-passed to Loader.for(...), the ... forwarding shares the internal kwargs hash across all expansion sites. When new(...) destructures them in initialize, it empties the same hash already stored in the executor's loader key, breaking loader reuse.

This only manifests when .for() is called through an intermediary that captures kwargs as named parameters and re-passes the, a common pattern in subclasses:

```ruby
  def self.load(model_class, id, key: :id, preload: true, **conditions)
    self.for(model_class, key: key, preload: preload, **conditions).load(id)
  end
```
`Direct .for(key: 'value')` calls are unaffected, which is why the bug is subtle.

1. loader_key_for(...) captures kwargs into the key: [self, {key: :id, ...}, [model]]
2. new(...) in the block shares the same kwargs hash - initialize destructures it, emptying the hash
3. The stored key becomes [self, {}, [model]]
4. Next lookup with {key: :id, ...} doesn't match {} - a new loader is created.

I've made thanks to Claude that helped me to identify this problem in our codebase and pointed out to this.