### PR TITLE
Fix kwargs hash sharing in Loader.for on Ruby 4.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.7, 3.0, 3.1, 3.2, 3.3]
+        ruby: [3.0, 3.1, 3.2, 3.3, 3.4, 4.0]
         graphql_version: ['~> 1.13', '~> 2.0']
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/graphql-batch.gemspec
+++ b/graphql-batch.gemspec
@@ -25,4 +25,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "byebug" if RUBY_ENGINE == 'ruby'
   spec.add_development_dependency "rake", ">= 12.3.3"
   spec.add_development_dependency "minitest"
+  # graphql 1.13.x requires ostruct, which was removed from default gems in Ruby 4.0.
+  spec.add_development_dependency "ostruct"
 end

--- a/graphql-batch.gemspec
+++ b/graphql-batch.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/Shopify/graphql-batch"
   spec.license       = "MIT"
 
-  spec.required_ruby_version = ">= 2.7"
+  spec.required_ruby_version = ">= 3.0"
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.bindir        = "exe"

--- a/lib/graphql/batch/loader.rb
+++ b/lib/graphql/batch/loader.rb
@@ -1,31 +1,24 @@
 module GraphQL::Batch
   class Loader
-    # Use new argument forwarding syntax if available as an optimization
-    if RUBY_ENGINE && Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.7")
-      class_eval(<<~RUBY, __FILE__, __LINE__ + 1)
-        def self.for(...)
-          current_executor.loader(loader_key_for(...)) { new(...) }
-        end
-      RUBY
-    else
-      def self.for(*group_args)
-        current_executor.loader(loader_key_for(*group_args)) { new(*group_args) }
-      end
-    end
-
-    def self.loader_key_for(*group_args, **group_kwargs)
-      [self, group_kwargs, group_args]
-    end
-
-    def self.load(key)
-      self.for.load(key)
-    end
-
-    def self.load_many(keys)
-      self.for.load_many(keys)
-    end
-
     class << self
+      def for(*group_args, **group_kwargs)
+        current_executor.loader(loader_key_for(*group_args, **group_kwargs)) do
+          new(*group_args, **group_kwargs)
+        end
+      end
+
+      def loader_key_for(*group_args, **group_kwargs)
+        [self, group_kwargs, group_args]
+      end
+
+      def load(key)
+        self.for.load(key)
+      end
+
+      def load_many(keys)
+        self.for.load_many(keys)
+      end
+
       private
 
       def current_executor

--- a/test/loader_test.rb
+++ b/test/loader_test.rb
@@ -63,6 +63,22 @@ class GraphQL::Batch::LoaderTest < Minitest::Test
     end
   end
 
+  class KwargsGroupCountLoader < GraphQL::Batch::Loader
+    def initialize(group, key: :id, preload: true, **conditions)
+    end
+
+    def perform(keys)
+      keys.each { |key| fulfill(key, keys.size) }
+    end
+
+    # Re-passes kwargs through a method that destructures them. On Ruby 4.0,
+    # `...` forwarding shares the kwargs hash across expansion sites, so
+    # destructuring in `new(...)` would drain the hash stored in the loader key.
+    def self.load_via_intermediary(group, load_key, key: :id, preload: true, **conditions)
+      self.for(group, key: key, preload: preload, **conditions).load(load_key)
+    end
+  end
+
   def setup
     GraphQL::Batch::Executor.current = GraphQL::Batch::Executor.new
   end
@@ -88,6 +104,15 @@ class GraphQL::Batch::LoaderTest < Minitest::Test
       GroupCountLoader.for('two').load(:a),
       GroupCountLoader.for('one').load(:a),
       GroupCountLoader.for('two').load(:b),
+    ])
+    assert_equal [2, 1, 2], group.sync
+  end
+
+  def test_query_group_with_kwargs_forwarded_via_intermediary
+    group = Promise.all([
+      KwargsGroupCountLoader.load_via_intermediary('two', :a),
+      KwargsGroupCountLoader.load_via_intermediary('one', :a),
+      KwargsGroupCountLoader.load_via_intermediary('two', :b),
     ])
     assert_equal [2, 1, 2], group.sync
   end


### PR DESCRIPTION
Alternative to https://github.com/Shopify/graphql-batch/pull/207

Ruby 4.0 reuses the same internal kwargs hash across `...` expansion sites in one method. `new(...)` destructuring kwargs in `initialize` drained the same hash stored in the loader key, silently breaking loader reuse when kwargs flowed through an intermediary method that destructured-and-re-packed them.

Replace `...` with explicit `*args, **kwargs` so each call site allocates a fresh hash. With `...` gone, the Ruby 2.6 parser workaround (class_eval heredoc + version guard) is unnecessary, so bump the minimum to 3.0 and drop it. CI matrix adds 3.4 and 4.0.